### PR TITLE
chore (style): apply rustfmt (except for tests) and eliminate trailing whitespaces

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,20 +8,20 @@
 // This file was created as part of a University of St Andrews Computer Science BSC Senior Honours Dissertation Project.
 
 /// The errors used within the SacnLibrary. The ErrorKind subsection of this within the documentation contains details of all the errors.
-/// 
+///
 /// Errors from external sources are wrapped within this error-chain.
-/// 
+///
 /// Io errors from std::io::Error are wrapped within Io(::std::io::Error)
-/// 
+///
 /// String errors from std::str::Utf8Error are wrapped within Str(::std::str::Utf8Error)
-/// 
+///
 /// Uuid errors from uuid::ParseError are wrapped within Uuid(uuid::ParseError)
-/// 
-/// 
+///
+///
 /// ParsePack related errors come within their own family wrapped inside this error to allow easy matching (can just match for SacnParsePackError rather than a specific).
-/// 
+///
 /// SacnParsePackError(sacn_parse_pack_error::Error, sacn_parse_pack_error::ErrorKind)
-/// 
+///
 /// Uses the error-chain crate to allow errors to allow more informative backtraces through error chaining.
 /// https://docs.rs/error-chain/0.12.2/error_chain/
 pub mod errors {
@@ -39,15 +39,15 @@ pub mod errors {
 
         links {
             // All parse/pack errors live within the same chain ('family') of errors as described in sacn_parse_packet_error.
-            SacnParsePackError(sacn_parse_pack_error::Error, sacn_parse_pack_error::ErrorKind); 
+            SacnParsePackError(sacn_parse_pack_error::Error, sacn_parse_pack_error::ErrorKind);
         }
 
         errors {
             /// Returned to indicate that an invalid or malformed source name was used.
-            /// 
+            ///
             /// # Arguments
             /// msg: A string describing why the source name is malformed.
-            /// 
+            ///
             MalformedSourceName(msg: String) {
                 description("The given source name was malformed and couldn't be used"),
                 display("The given source name was malformed and couldn't be used, msg: {}", msg)
@@ -56,115 +56,115 @@ pub mod errors {
             /// Attempted to perform an action using a priority value that is invalid. For example sending with a priority > 200.
             /// This is distinct from the SacnParsePackError(ParseInvalidPriority) as it is for a local use of an invalid priority
             /// rather than receiving an invalid priority from another source.
-            /// 
+            ///
             /// # Arguments
             /// msg: A string describing why the priority is invalid.
-            /// 
+            ///
             InvalidPriority(msg: String) {
                 description("Attempted to perform an action using a priority value that is invalid"),
                 display("Attempted to perform an action using a priority value that is invalid, msg: {}", msg)
             }
-            
-            /// Used to indicate that the limit for the number of supported sources has been reached. 
+
+            /// Used to indicate that the limit for the number of supported sources has been reached.
             /// This is based on unique CID values.
             /// as per ANSI E1.31-2018 Section 6.2.3.3.
-            /// 
+            ///
             /// # Arguments
             /// msg: A string describing why the sources exceeded error was returned.
-            /// 
+            ///
             SourcesExceededError(msg: String) {
                 description("Limit for the number of supported sources has been reached"),
                 display("Limit for the number of supported sources has been reached, msg: {}", msg)
             }
 
             /// A source was discovered by a receiver with the announce_discovery_flag set to true.
-            /// 
+            ///
             /// # Arguments
             /// source_name: The name of the source discovered.
-            /// 
+            ///
             SourceDiscovered(source_name: String) {
                 description("A source was discovered by a receiver with the announce_discovery_flag set to true"),
                 display("A source was discovered by a receiver with the announce_discovery_flag set to true, source name: {}", source_name)
             }
 
             /// Attempted to exceed the capacity of a single universe (packet::UNIVERSE_CHANNEL_CAPACITY).
-            /// 
+            ///
             /// # Arguments
             /// msg: A string describing why/how the universe capacity was exceeded.
-            /// 
+            ///
             ExceedUniverseCapacity(msg: String) {
                 description("Attempted to exceed the capacity of a single universe"),
                 display("Attempted to exceed the capacity of a single universe, msg: {}", msg)
             }
 
-            /// Attempted to use illegal universe, outwith allowed range of [E131_MIN_MULTICAST_UNIVERSE, E131_MAX_MULTICAST_UNIVERSE] 
+            /// Attempted to use illegal universe, outwith allowed range of [E131_MIN_MULTICAST_UNIVERSE, E131_MAX_MULTICAST_UNIVERSE]
             /// + E131_DISCOVERY_UNIVERSE inclusive
-            /// 
+            ///
             /// # Arguments
             /// msg: A string describing why/how the universe is an illegal universe.
-            /// 
+            ///
             IllegalUniverse(msg: String) {
-                description("Attempted to use illegal universe, outwith allowed range of [E131_MIN_MULTICAST_UNIVERSE 
+                description("Attempted to use illegal universe, outwith allowed range of [E131_MIN_MULTICAST_UNIVERSE
                 - E131_MAX_MULTICAST_UNIVERSE] + E131_DISCOVERY_UNIVERSE inclusive"),
                 display("illegal universe used, outwith allowed range, msg: {}", msg)
             }
 
             /// Attempted to use a universe that wasn't first registered for use.
             /// To send from a universe with a sender it must first be registered. This allows universe discovery adverts to include the universe.
-            /// 
+            ///
             /// # Arguments
             /// msg: A string describing why the error was returned.
-            /// 
+            ///
             UniverseNotRegistered(msg: String) {
                 description("Attempted to use a universe that wasn't first registered for use"),
                 display("Attempted to use a universe that wasn't first registered for use, msg: {}", msg)
             }
 
             /// Ip version (ipv4 or ipv6) used when the other is expected.
-            /// 
+            ///
             /// # Arguments
             /// msg: A string describing the situation where the wrong IpVersion was encountered.
-            /// 
+            ///
             IpVersionError(msg: String) {
                 description("Ip version (ipv4 or ipv6) used when the other is expected"),
                 display("Ip version (ipv4 or ipv6) used when the other is expected, msg: {}", msg)
             }
 
             /// Attempted to use an unsupported (not Ipv4 or Ipv6) IP version.
-            /// 
+            ///
             /// # Arguments
             /// msg: A string describing the situation where an unsupported IP version is used.
-            /// 
+            ///
             UnsupportedIpVersion(msg: String) {
                 description("Attempted to use an unsupported (not Ipv4 or Ipv6) IP version"),
                 display("Attempted to use an unsupported (not Ipv4 or Ipv6) IP version, msg: {}", msg)
             }
 
             /// Attempted to use a sender which has already been terminated.
-            /// 
+            ///
             /// # Arguments
             /// msg: A string describing why the error was returned.
-            /// 
+            ///
             SenderAlreadyTerminated(msg: String) {
                 description("Attempted to use a sender which has already been terminated"),
                 display("Attempted to use a sender which has already been terminated, msg: {}", msg)
             }
 
             /// An error was encountered when attempting to merge DMX data together.
-            /// 
+            ///
             /// # Arguments
             /// msg: A string describing why the error was returned.
-            /// 
+            ///
             DmxMergeError(msg: String) {
                 description("Error when merging DMX data"),
                 display("Error when merging DMX data, msg: {}", msg)
             }
 
             /// Packet was received out of sequence and so should be discarded.
-            /// 
+            ///
             /// # Arguments
             /// msg: A string describing why the error was returned.
-            /// 
+            ///
             OutOfSequence(msg: String) {
                 description("Packet was received out of sequence and so should be discarded"),
                 display("Packet was received out of sequence and so should be discarded, msg: {}", msg)
@@ -172,26 +172,26 @@ pub mod errors {
 
             /// A source terminated a universe and this was detected when trying to receive data.
             /// This is only returned if the announce_stream_termination flag is set to true (default false).
-            /// 
+            ///
             /// # Arguments
-            /// 
+            ///
             /// src_cid: The CID of the source which sent the termination packet.
-            /// 
+            ///
             /// uni: The universe that the termination packet is for.
-            /// 
+            ///
             UniverseTerminated(src_cid: Uuid, uni: u16) {
                 description("A source terminated a universe and this was detected when trying to receive data"),
                 display("Source cid: {:?} terminated universe: {}", src_cid, uni)
             }
 
             /// A source universe timed out as no data was received on that universe within E131_NETWORK_DATA_LOSS_TIMEOUT as per ANSI E1.31-2018 Section 6.7.1.
-            /// 
+            ///
             /// # Arguments
-            /// 
+            ///
             /// src_cid: The CID of the source which timed out.
-            /// 
+            ///
             /// uni: The universe that timed out.
-            /// 
+            ///
             UniverseTimeout(src_cid: Uuid, uni: u16) {
                 description("A source universe timed out as no data was received within E131_NETWORK_DATA_LOSS_TIMEOUT as per ANSI E1.31-2018 Section 6.7.1"),
                 display("(Source,Universe) timed out: ({},{})", src_cid, uni)
@@ -199,21 +199,21 @@ pub mod errors {
 
             /// When looking for a specific universe it wasn't found. This might happen for example if trying to mute a universe on a receiver that
             /// wasn't being listened to.
-            /// 
+            ///
             /// # Arguments
             /// msg: A message describing why this error was returned.
-            /// 
+            ///
             UniverseNotFound(msg: String) {
                 description("When looking for a specific universe it wasn't found"),
                 display("When looking for a specific universe it wasn't found, msg: {}", msg)
             }
 
-            /// Attempted to find a source and failed. This might happen on a receiver for example if trying to remove a source which was never 
+            /// Attempted to find a source and failed. This might happen on a receiver for example if trying to remove a source which was never
             /// registered or discovered.
-            /// 
+            ///
             /// # Arguments
             /// msg: A message describing why this error was returned / when the source was not found.
-            /// 
+            ///
             SourceNotFound(msg: String) {
                 description("When looking for a specific source it wasn't found"),
                 display("Source not found, msg: {}", msg)
@@ -221,10 +221,10 @@ pub mod errors {
 
             /// Thrown to indicate that the operation attempted is unsupported on the current OS
             /// For example this is used to indicate that multicast-IPv6 isn't supported current on Windows.
-            /// 
+            ///
             /// # Arguments
             /// msg: A message describing why this error was returned / the operation that was not supported.
-            /// 
+            ///
             OsOperationUnsupported(msg: String) {
                 description("Thrown to indicate that the operation attempted is unsupported on the current OS"),
                 display("Operation attempted is unsupported on the current OS, msg: {}", msg)
@@ -234,10 +234,10 @@ pub mod errors {
             /// This is currently only thrown if the source mutex is poisoned by a thread with access panic-ing.
             /// This prevents the panic propagating to the user of this library and allows them to handle it appropriately
             /// such as by creating a new source.
-            /// 
+            ///
             /// # Arguments
             /// msg: A message providing further details (if any) as to why the SourceCorrupt error was returned.
-            /// 
+            ///
             SourceCorrupt(msg: String) {
                 description("The sACN source has corrupted due to an internal panic! and should no longer be used"),
                 display("The sACN source has corrupted due to an internal panic! and should no longer be used, {}", msg)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,36 +9,36 @@
 
 //! Implementation of the sACN network protocol.
 //!
-//! This crate implements the Streaming ACN (sACN) network protocol as specified in ANSI E1.31-2018. Streaming ACN is built on top of and is 
+//! This crate implements the Streaming ACN (sACN) network protocol as specified in ANSI E1.31-2018. Streaming ACN is built on top of and is
 //! compatible with the ACN protocol suite (ANSI E1.17-2015). This library supports sending and receiving data, universe synchronisation and
 //! universe discovery. This library supports linux (fully) and windows (no receiving multicast) and IP unicast, multicast and broadcast.
-//! 
+//!
 //! Installation instructions are detailed within the README file.
-//! 
-//! 
-//! 
+//!
+//!
+//!
 //! This file was modified as part of a University of St Andrews Computer Science BSC Senior Honours Dissertation Project.
-//! 
+//!
 //! # Examples
-//! 
+//!
 //! Creating an sACN receiver and receiving data. This automatically handles receiving synchronised data at the right time with the array of received data
 //! containing all the data which should be acted upon at the same time (so if there are 2 synchronised data packets the array will have length 2).
 //! ```
 //! use sacn::receive::SacnReceiver;
 //! use sacn::packet::ACN_SDT_MULTICAST_PORT;
-//! 
+//!
 //! use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 //! use std::time::Duration;
-//! 
+//!
 //! const UNIVERSE1: u16 = 1;
 //! const TIMEOUT: Option<Duration> = Some(Duration::from_secs(1)); // A timeout of None means blocking behaviour, some indicates the actual timeout.
-//! 
+//!
 //! let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), ACN_SDT_MULTICAST_PORT);
 //!
 //! let mut dmx_rcv = SacnReceiver::with_ip(addr, None).unwrap();
 //!
 //! dmx_rcv.listen_universes(&[UNIVERSE1]).unwrap();
-//! 
+//!
 //! // .recv(TIMEOUT) handles processing synchronised as-well as normal data.
 //! match dmx_rcv.recv(TIMEOUT) {
 //!     Err(e) => {
@@ -51,30 +51,30 @@
 //!     }
 //! }
 //! ```
-//! 
+//!
 //! Creating an sACN receiver and checking for discovered sources through universe discovery.
 //! ```
 //! use sacn::receive::SacnReceiver;
 //! use sacn::packet::ACN_SDT_MULTICAST_PORT;
-//! 
+//!
 //! use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 //! use std::time::Duration;
-//! 
+//!
 //! const TIMEOUT: Option<Duration> = Some(Duration::from_secs(1)); // A timeout of None means blocking behaviour, some indicates the actual timeout.
-//! 
+//!
 //! let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), ACN_SDT_MULTICAST_PORT);
 //!
 //! // Creating the receiver, automatically listens for universe discovery packets.
 //! let mut dmx_rcv = SacnReceiver::with_ip(addr, None).unwrap();
-//! 
+//!
 //! // Cause source discovery to be announced by a returned error. If this isn't true then discovery packets are still handled by the user must poll
 //! // the discovered sources list periodically as there will be no announcement that a discovery packet has been processed. By default this option is
 //! // off (false) based on the assumption that when receiving data the majority of the time the receiver just wants to process more data from the same
 //! // universe and doesn't want to discover sources.
 //! dmx_rcv.set_announce_source_discovery(true);
-//! 
+//!
 //! // Receive for a short period, no data is expected but this allows universe discovery packets to be received.
-//! // This example will always timeout if run in isolation as there are no sources running on the network. 
+//! // This example will always timeout if run in isolation as there are no sources running on the network.
 //! match dmx_rcv.recv(TIMEOUT) {
 //!     Err(e) => {
 //!         match e.kind() {
@@ -93,9 +93,9 @@
 //!     }
 //! }
 //! ```
-//! 
+//!
 //! Creating a sACN sender and sending some unsychronised data. An sACNSender automatically sends universe discovery packets.
-//! 
+//!
 //! ```
 //! use sacn::source::SacnSource;
 //! use sacn::packet::ACN_SDT_MULTICAST_PORT;
@@ -115,15 +115,15 @@
 //! let mut data: Vec<u8> = vec![0, 0, 0, 0, 255, 255, 128, 128]; // Some arbitrary data, must have length <= 513 (including start-code).
 //!
 //! src.send(&[universe], &data, Some(priority), dst_ip, sync_uni).unwrap(); // Actually send the data
-//! 
+//!
 //! ```
-//! 
-//! Creating a sACN sender and sending some synchronised data. 
-//! 
+//!
+//! Creating a sACN sender and sending some synchronised data.
+//!
 //! ```
 //! use sacn::source::SacnSource;
 //! use sacn::packet::ACN_SDT_MULTICAST_PORT;
-//! 
+//!
 //! use std::net::{IpAddr, SocketAddr};
 //! use std::thread::sleep;
 //! use std::time::Duration;
@@ -143,20 +143,20 @@
 //!
 //! // Actually send the data, since the sync_uni is not 0 the data will be synchronised at the receiver (if the receiver supports synchronisation).
 //! src.send(&[universe], &data, Some(priority), dst_ip, sync_uni).unwrap();
-//! 
+//!
 //! // A small delay between sending data and sending the sync packet as recommend in ANSI E1.31-2018 Section 11.2.2.
 //! sleep(Duration::from_millis(10));
-//! 
+//!
 //! // To actually trigger the data need to send a synchronisation packet like so.
 //! src.send_sync_packet(sync_uni.unwrap(), dst_ip).unwrap();
 //! ```
-//! 
+//!
 //! Creating a sACN sender and sending data using unicast.
-//! 
+//!
 //! ```
 //! use sacn::source::SacnSource;
 //! use sacn::packet::ACN_SDT_MULTICAST_PORT;
-//! 
+//!
 //! use std::net::{IpAddr, SocketAddr};
 //! use std::thread::sleep;
 //! use std::time::Duration;
@@ -168,7 +168,7 @@
 //! let universe: u16 = 1;                        // Universe the data is to be sent on.
 //! let sync_uni: Option<u16> = None;             // Data packets are unsynchronised in this example but unicast transmission supports synchronised and unsynchronised sending.
 //! let priority: Option<u8> = Some(100);                       // The priority for the sending data, must be 1-200 inclusive,  None means use default.
-//! 
+//!
 //! // To send using unicast the dst_ip argument is set to a Some() value with the address to send the data to. By default the port should be the
 //! // ACN_SDT_MULTICAST_PORT but this can be configured differently if required in a specific situation. Change this address to the correct address for your
 //! // application, 192.168.0.1 is just a stand-in.
@@ -186,7 +186,7 @@
 #![doc(html_root_url = "https://docs.rs/sacn/")]
 // #![warn(missing_docs)]
 // Recursion limit for error_chain.
-#![recursion_limit="1024"]
+#![recursion_limit = "1024"]
 
 #[macro_use]
 extern crate error_chain;
@@ -199,9 +199,9 @@ pub mod sacn_parse_pack_error;
 /// The errors used within the sACN crate, parse/pack errors are seperated out into sacn_parse_pack_error.
 pub mod error;
 
+extern crate libc;
 /// The library is built on top of socket2 to provide the underlying UDP networking interface.
 extern crate socket2;
-extern crate libc;
 
 /// The core crate is used for string processing during packet parsing/packing as well as to provide access to the Hash trait.
 extern crate core;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -177,26 +177,26 @@ const E131_SEQ_NUM_FIELD_LENGTH: usize = 1;
 /// The length in bytes of the options field within an ANSI E1.31-2018 data packet as defined in ANSI E1.31-2018 Section 4, Table 4-1.
 const E131_OPTIONS_FIELD_LENGTH: usize = 1;
 
-/// The length in bytes of a universe field within an ANSI E1.31-2018 packet as defined in ANSI E1.31-2018 Section 4, Table 4-1, 4-3. 
+/// The length in bytes of a universe field within an ANSI E1.31-2018 packet as defined in ANSI E1.31-2018 Section 4, Table 4-1, 4-3.
 const E131_UNIVERSE_FIELD_LENGTH: usize = 2;
 
 /// The length in bytes of the Vector field within the DMP layer of an ANSI E1.31-2018 data packet as per ANSI E1.31-2018
 /// Section 4, Table 4-1.
 const E131_DATA_PACKET_DMP_LAYER_VECTOR_FIELD_LENGTH: usize = 1;
 
-/// The length in bytes of the "Address Type and Data Type" field within an ANSI E1.31-2018 data packet DMP layer as per 
+/// The length in bytes of the "Address Type and Data Type" field within an ANSI E1.31-2018 data packet DMP layer as per
 /// ANSI E1.31-2018 Section 4, Table 4-1.
 const E131_DATA_PACKET_DMP_LAYER_ADDRESS_DATA_FIELD_LENGTH: usize = 1;
 
-/// The length in bytes of the "First Property Address" field within an ANSI E1.31-2018 data packet DMP layer as per 
+/// The length in bytes of the "First Property Address" field within an ANSI E1.31-2018 data packet DMP layer as per
 /// ANSI E1.31-2018 Section 4, Table 4-1.
 const E131_DATA_PACKET_DMP_LAYER_FIRST_PROPERTY_ADDRESS_FIELD_LENGTH: usize = 2;
 
-/// The length in bytes of the "Address Increment" field within an ANSI E1.31-2018 data packet DMP layer as per 
+/// The length in bytes of the "Address Increment" field within an ANSI E1.31-2018 data packet DMP layer as per
 /// ANSI E1.31-2018 Section 4, Table 4-1.
 const E131_DATA_PACKET_DMP_LAYER_ADDRESS_INCREMENT_FIELD_LENGTH: usize = 2;
 
-/// The length in bytes of the "Property value count" field within an ANSI E1.31-2018 data packet DMP layer as per 
+/// The length in bytes of the "Property value count" field within an ANSI E1.31-2018 data packet DMP layer as per
 /// ANSI E1.31-2018 Section 4, Table 4-1.
 const E131_DATA_PACKET_DMP_LAYER_PROPERTY_VALUE_COUNT_FIELD_LENGTH: usize = 2;
 
@@ -212,15 +212,15 @@ const E131_DISCOVERY_LAYER_PAGE_FIELD_LENGTH: usize = 1;
 /// 1 bytes as per ANSI E1.31-2018 Section 4, Table 4-3.
 const E131_DISCOVERY_LAYER_LAST_PAGE_FIELD_LENGTH: usize = 1;
 
-/// The value of the "Address Type and Data Type" field within an ANSI E1.31-2018 data packet DMP layer as per ANSI E1.31-2018 
+/// The value of the "Address Type and Data Type" field within an ANSI E1.31-2018 data packet DMP layer as per ANSI E1.31-2018
 /// Section 4, Table 4-1.
 const E131_DMP_LAYER_ADDRESS_DATA_FIELD: u8 = 0xa1;
 
-/// The value of the "First Property Address" field within an ANSI E1.31-2018 data packet DMP layer as per ANSI E1.31-2018 
+/// The value of the "First Property Address" field within an ANSI E1.31-2018 data packet DMP layer as per ANSI E1.31-2018
 /// Section 4, Table 4-1.
 const E131_DATA_PACKET_DMP_LAYER_FIRST_PROPERTY_FIELD: u16 = 0x0000;
 
-/// The value of the "Address Increment" field within an ANSI E1.31-2018 data packet DMP layer as per ANSI E1.31-2018 
+/// The value of the "Address Increment" field within an ANSI E1.31-2018 data packet DMP layer as per ANSI E1.31-2018
 /// Section 4, Table 4-1.
 const E131_DATA_PACKET_DMP_LAYER_ADDRESS_INCREMENT: u16 = 0x0001;
 
@@ -234,13 +234,16 @@ const E131_POSTAMBLE_SIZE: u16 = 0x0;
 
 /// The E131 ACN packet identifier field value. Must be 0x41 0x53 0x43 0x2d 0x45 0x31 0x2e 0x31 0x37 0x00 0x00 0x00 as per
 /// ANSI E1.31-2018 Section 5.3.
-const E131_ACN_PACKET_IDENTIFIER: [u8; 12] = [0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00];
+const E131_ACN_PACKET_IDENTIFIER: [u8; 12] = [
+    0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
+];
 
 /// The E131 CID field length in bytes as per ANSI E1.31-2018 Section 4 Table 4-1, 4-2, 4-3.
 pub const E131_CID_FIELD_LENGTH: usize = 16;
 
 // The exclusive end index of the CID field. Calculated based on previous values defined in ANSI E1.31-2018 Section 4 Table 4-1, 4-2, 4-3.
-const E131_CID_END_INDEX: usize = E131_PDU_LENGTH_FLAGS_LENGTH + E131_ROOT_LAYER_VECTOR_LENGTH + E131_CID_FIELD_LENGTH;
+const E131_CID_END_INDEX: usize =
+    E131_PDU_LENGTH_FLAGS_LENGTH + E131_ROOT_LAYER_VECTOR_LENGTH + E131_CID_FIELD_LENGTH;
 
 /// The length of the Source Name field in bytes in an ANSI E1.31-2018 packet as per ANSI E1.31-2018 Section 4, Table 4-1, 4-2, 4-3.
 pub const E131_SOURCE_NAME_FIELD_LENGTH: usize = 64;
@@ -326,7 +329,7 @@ pub const UNIVERSE_DISCOVERY_SOURCE_TIMEOUT: Duration = E131_NETWORK_DATA_LOSS_T
 /// # Errors
 /// IllegalUniverse: Returned if the given universe is outwith the allowed range of universes,
 ///     see (is_universe_in_range)[fn.is_universe_in_range.packet].
-/// 
+///
 pub fn universe_to_ipv4_multicast_addr(universe: u16) -> Result<SockAddr> {
     is_universe_in_range(universe)?;
 
@@ -351,7 +354,7 @@ pub fn universe_to_ipv4_multicast_addr(universe: u16) -> Result<SockAddr> {
 /// # Errors
 /// IllegalUniverse: Returned if the given universe is outwith the allowed range of universes,
 ///     see (is_universe_in_range)[fn.is_universe_in_range.packet].
-/// 
+///
 pub fn universe_to_ipv6_multicast_addr(universe: u16) -> Result<SockAddr> {
     is_universe_in_range(universe)?;
 
@@ -393,13 +396,13 @@ fn zeros(buf: &mut [u8], n: usize) {
 }
 
 /// Takes the given byte buffer (e.g. a c char array) and parses it into a rust &str.
-/// 
+///
 /// # Arguments
 /// buf: The byte buffer to parse into a str.
-/// 
+///
 /// # Errors
 /// SourceNameInvalid: Returned if the source name is not null terminated as required by ANSI E1.31-2018 Section 6.2.2
-/// 
+///
 #[inline]
 fn parse_source_name_str(buf: &[u8]) -> Result<&str> {
     let mut source_name_length = buf.len();
@@ -411,7 +414,11 @@ fn parse_source_name_str(buf: &[u8]) -> Result<&str> {
     }
 
     if source_name_length == buf.len() && buf[buf.len() - 1] != 0 {
-        bail!(ErrorKind::SacnParsePackError(sacn_parse_pack_error::ErrorKind::SourceNameInvalid("Packet source name not null terminated".to_string())));
+        bail!(ErrorKind::SacnParsePackError(
+            sacn_parse_pack_error::ErrorKind::SourceNameInvalid(
+                "Packet source name not null terminated".to_string()
+            )
+        ));
     }
 
     Ok(str::from_utf8(&buf[..source_name_length])?)
@@ -518,32 +525,39 @@ struct PduInfo {
 }
 
 /// Takes the given byte buffer and parses the flags, length and vector fields into a PduInfo struct.
-/// 
+///
 /// # Arguments
 /// buf: The raw byte buffer.
-/// 
+///
 /// vector_length: The length of the vectorfield in bytes.
-/// 
+///
 /// # Errors
 /// ParseInsufficientData: If the length of the buffer is less than the flag, length and vector fields (E131_PDU_LENGTH_FLAGS_LENGTH + vector_length).
-/// 
+///
 /// ParsePduInvalidFlags: If the flags parsed don't match the flags expected for an ANSI E1.31-2018 packet as per ANSI E1.31-2018 Section 4 Table 4-1, 4-2, 4-3.
-/// 
+///
 fn pdu_info(buf: &[u8], vector_length: usize) -> Result<PduInfo> {
     if buf.len() < E131_PDU_LENGTH_FLAGS_LENGTH + vector_length {
-        bail!(ErrorKind::SacnParsePackError(sacn_parse_pack_error::ErrorKind::ParseInsufficientData("Insufficient data when parsing pdu_info, no flags or length field".to_string())));
+        bail!(ErrorKind::SacnParsePackError(
+            sacn_parse_pack_error::ErrorKind::ParseInsufficientData(
+                "Insufficient data when parsing pdu_info, no flags or length field".to_string()
+            )
+        ));
     }
 
     // Flags
     let flags = buf[0] & 0xf0; // Flags are stored in the top 4 bits.
     if flags != E131_PDU_FLAGS {
-        bail!(ErrorKind::SacnParsePackError(sacn_parse_pack_error::ErrorKind::ParsePduInvalidFlags(flags)));
+        bail!(ErrorKind::SacnParsePackError(
+            sacn_parse_pack_error::ErrorKind::ParsePduInvalidFlags(flags)
+        ));
     }
     // Length
-    let length = (NetworkEndian::read_u16(&buf[0 .. E131_PDU_LENGTH_FLAGS_LENGTH]) & 0x0fff) as usize;
+    let length = (NetworkEndian::read_u16(&buf[0..E131_PDU_LENGTH_FLAGS_LENGTH]) & 0x0fff) as usize;
 
     // Vector
-    let vector = NetworkEndian::read_uint(&buf[E131_PDU_LENGTH_FLAGS_LENGTH .. ], vector_length) as u32;
+    let vector =
+        NetworkEndian::read_uint(&buf[E131_PDU_LENGTH_FLAGS_LENGTH..], vector_length) as u32;
 
     Ok(PduInfo { length, vector })
 }
@@ -591,7 +605,7 @@ macro_rules! impl_e131_root_layer {
                 if vector != VECTOR_ROOT_E131_DATA && vector != VECTOR_ROOT_E131_EXTENDED {
                     bail!(ErrorKind::SacnParsePackError(sacn_parse_pack_error::ErrorKind::PduInvalidVector(vector)));
                 }
-                
+
                 // CID
                 let cid = Uuid::from_bytes(&buf[E131_PDU_LENGTH_FLAGS_LENGTH + E131_ROOT_LAYER_VECTOR_LENGTH .. E131_CID_END_INDEX])?;
 
@@ -1069,13 +1083,16 @@ pub struct SynchronizationPacketFramingLayer {
 // Constants are replaced inline so this increases readability by removing magic numbers without affecting runtime performance.
 // Theses indexes are only valid within the scope of this part of the protocol (SynchronisationPacketFramingLayer).
 const E131_SYNC_FRAMING_LAYER_VECTOR_FIELD_INDEX: usize = E131_PDU_LENGTH_FLAGS_LENGTH;
-const E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_INDEX: usize = E131_SYNC_FRAMING_LAYER_VECTOR_FIELD_INDEX + E131_FRAMING_LAYER_VECTOR_LENGTH;
-const E131_SYNC_FRAMING_LAYER_SYNC_ADDRESS_FIELD_INDEX: usize = E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_INDEX + E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_LENGTH;
-const E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX: usize = E131_SYNC_FRAMING_LAYER_SYNC_ADDRESS_FIELD_INDEX + E131_SYNC_ADDR_FIELD_LENGTH;
-const E131_SYNC_FRAMING_LAYER_END_INDEX: usize = E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX + E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_LENGTH;
+const E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_INDEX: usize =
+    E131_SYNC_FRAMING_LAYER_VECTOR_FIELD_INDEX + E131_FRAMING_LAYER_VECTOR_LENGTH;
+const E131_SYNC_FRAMING_LAYER_SYNC_ADDRESS_FIELD_INDEX: usize =
+    E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_INDEX + E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_LENGTH;
+const E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX: usize =
+    E131_SYNC_FRAMING_LAYER_SYNC_ADDRESS_FIELD_INDEX + E131_SYNC_ADDR_FIELD_LENGTH;
+const E131_SYNC_FRAMING_LAYER_END_INDEX: usize =
+    E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX + E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_LENGTH;
 
 impl Pdu for SynchronizationPacketFramingLayer {
-
     fn parse(buf: &[u8]) -> Result<SynchronizationPacketFramingLayer> {
         // Length and Vector
         let PduInfo { length, vector } = pdu_info(&buf, E131_FRAMING_LAYER_VECTOR_LENGTH)?;
@@ -1084,29 +1101,41 @@ impl Pdu for SynchronizationPacketFramingLayer {
         }
 
         if vector != VECTOR_E131_EXTENDED_SYNCHRONIZATION {
-            bail!(ErrorKind::SacnParsePackError(sacn_parse_pack_error::ErrorKind::PduInvalidVector(vector)));
+            bail!(ErrorKind::SacnParsePackError(
+                sacn_parse_pack_error::ErrorKind::PduInvalidVector(vector)
+            ));
         }
 
         if length != E131_UNIVERSE_SYNC_PACKET_FRAMING_LAYER_LENGTH {
             bail!(ErrorKind::SacnParsePackError(
-                sacn_parse_pack_error::ErrorKind::PduInvalidLength(length))); 
+                sacn_parse_pack_error::ErrorKind::PduInvalidLength(length)
+            ));
         }
 
         // Sequence Number
         let sequence_number = buf[E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_INDEX];
 
         // Synchronization Address
-        let synchronization_address = NetworkEndian::read_u16(&buf[E131_SYNC_FRAMING_LAYER_SYNC_ADDRESS_FIELD_INDEX .. E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX]);
+        let synchronization_address = NetworkEndian::read_u16(
+            &buf[E131_SYNC_FRAMING_LAYER_SYNC_ADDRESS_FIELD_INDEX
+                ..E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX],
+        );
 
-        if synchronization_address > E131_MAX_MULTICAST_UNIVERSE || synchronization_address < E131_MIN_MULTICAST_UNIVERSE {
-            bail!(
-                ErrorKind::SacnParsePackError(
+        if synchronization_address > E131_MAX_MULTICAST_UNIVERSE
+            || synchronization_address < E131_MIN_MULTICAST_UNIVERSE
+        {
+            bail!(ErrorKind::SacnParsePackError(
                 sacn_parse_pack_error::ErrorKind::ParseInvalidUniverse(
-                    format!("Synchronisation address value: {} is outwith the allowed range", synchronization_address).to_string()))
-            );
+                    format!(
+                        "Synchronisation address value: {} is outwith the allowed range",
+                        synchronization_address
+                    )
+                    .to_string()
+                )
+            ));
         }
 
-        // Reserved fields (2 bytes right immediately after the synchronisation address) should be ignored by receivers as per 
+        // Reserved fields (2 bytes right immediately after the synchronisation address) should be ignored by receivers as per
         // ANSI E1.31-2018 Section 6.3.4.
 
         Ok(SynchronizationPacketFramingLayer {
@@ -1117,24 +1146,41 @@ impl Pdu for SynchronizationPacketFramingLayer {
 
     fn pack(&self, buf: &mut [u8]) -> Result<()> {
         if buf.len() < self.len() {
-            bail!(ErrorKind::SacnParsePackError(sacn_parse_pack_error::ErrorKind::PackBufferInsufficient("SynchronizationPacketFramingLayer pack buffer length insufficient".to_string())));
+            bail!(ErrorKind::SacnParsePackError(
+                sacn_parse_pack_error::ErrorKind::PackBufferInsufficient(
+                    "SynchronizationPacketFramingLayer pack buffer length insufficient".to_string()
+                )
+            ));
         }
 
         // Flags and Length
-        let flags_and_length = NetworkEndian::read_u16(&[E131_PDU_FLAGS, 0x0]) | (self.len() as u16) & 0x0fff;
-        NetworkEndian::write_u16(&mut buf[0.. E131_PDU_LENGTH_FLAGS_LENGTH], flags_and_length);
+        let flags_and_length =
+            NetworkEndian::read_u16(&[E131_PDU_FLAGS, 0x0]) | (self.len() as u16) & 0x0fff;
+        NetworkEndian::write_u16(&mut buf[0..E131_PDU_LENGTH_FLAGS_LENGTH], flags_and_length);
 
         // Vector
-        NetworkEndian::write_u32(&mut buf[E131_SYNC_FRAMING_LAYER_VECTOR_FIELD_INDEX .. E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_INDEX], VECTOR_E131_EXTENDED_SYNCHRONIZATION);
+        NetworkEndian::write_u32(
+            &mut buf[E131_SYNC_FRAMING_LAYER_VECTOR_FIELD_INDEX
+                ..E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_INDEX],
+            VECTOR_E131_EXTENDED_SYNCHRONIZATION,
+        );
 
         // Sequence Number
         buf[E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_INDEX] = self.sequence_number;
 
         // Synchronization Address
-        NetworkEndian::write_u16(&mut buf[E131_SYNC_FRAMING_LAYER_SYNC_ADDRESS_FIELD_INDEX .. E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX], self.synchronization_address);
+        NetworkEndian::write_u16(
+            &mut buf[E131_SYNC_FRAMING_LAYER_SYNC_ADDRESS_FIELD_INDEX
+                ..E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX],
+            self.synchronization_address,
+        );
 
         // Reserved, transmitted as zeros as per ANSI E1.31-2018 Section 6.3.4.
-        zeros(&mut buf[E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX .. E131_SYNC_FRAMING_LAYER_END_INDEX], E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_LENGTH);
+        zeros(
+            &mut buf
+                [E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX..E131_SYNC_FRAMING_LAYER_END_INDEX],
+            E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_LENGTH,
+        );
 
         Ok(())
     }
@@ -1400,26 +1446,26 @@ macro_rules! impl_universe_discovery_packet_universe_discovery_layer {
 }
 
 /// Takes the given buffer representing the "List of Universe" field in an ANSI E1.31-2018 discovery packet and parses it into the universe values.
-/// 
+///
 /// This enforces the requirement from ANSI E1.31-2018 Section 8.5 that the universes must be numerically sorted.
-/// 
+///
 /// # Arguments
 /// buf: The byte buffer to parse into the universe.
 /// length: The number of universes to attempt to parse from the buffer.
-/// 
+///
 /// # Errors
 /// ParseInvalidUniverseOrder: If the universes are not sorted in ascending order with no duplicates.
-/// 
+///
 /// ParseInsufficientData: If the buffer doesn't contain sufficient bytes and so cannot be parsed into the specified number of u16 universes.
-/// 
+///
 fn parse_universe_list<'a>(buf: &[u8], length: usize) -> Result<Cow<'a, [u16]>> {
     let mut universes: Vec<u16> = Vec::with_capacity(length);
     let mut i = 0;
 
     // Last_universe starts as a placeholder value that is guaranteed to be less than the lowest possible advertised universe.
-    // Cannot use 0 even though under ANSI E1.31-2018 it cannot be used for data or as a sync_address as it is reserved for future use 
+    // Cannot use 0 even though under ANSI E1.31-2018 it cannot be used for data or as a sync_address as it is reserved for future use
     // so may be used in future.
-    let mut last_universe: i32 = -1; 
+    let mut last_universe: i32 = -1;
 
     if buf.len() < length * E131_UNIVERSE_FIELD_LENGTH {
         bail!(ErrorKind::SacnParsePackError(
@@ -1427,10 +1473,11 @@ fn parse_universe_list<'a>(buf: &[u8], length: usize) -> Result<Cow<'a, [u16]>> 
                 format!("The given buffer of length {} bytes cannot be parsed into the given number of universes {}", buf.len(), length).to_string())));
     }
 
-    while i < (length * E131_UNIVERSE_FIELD_LENGTH)  {
-        let u = NetworkEndian::read_u16(&buf[i .. i + E131_UNIVERSE_FIELD_LENGTH]);
+    while i < (length * E131_UNIVERSE_FIELD_LENGTH) {
+        let u = NetworkEndian::read_u16(&buf[i..i + E131_UNIVERSE_FIELD_LENGTH]);
 
-        if (u as i32) > last_universe { // Enforce assending ordering of universes as per ANSI E1.31-2018 Section 8.5. 
+        if (u as i32) > last_universe {
+            // Enforce assending ordering of universes as per ANSI E1.31-2018 Section 8.5.
             universes.push(u);
             last_universe = u as i32;
             i = i + E131_UNIVERSE_FIELD_LENGTH; // Jump to the next universe.
@@ -1659,7 +1706,7 @@ mod test {
     }
 
     /// Verifies that the parameters are set correctly as per ANSI E1.31-2018 Appendix A: Defined Parameters (Normative).
-    /// This test is particularly useful at the maintenance stage as it will flag up if any protocol defined constant is changed. 
+    /// This test is particularly useful at the maintenance stage as it will flag up if any protocol defined constant is changed.
     #[test]
     fn check_ansi_e131_2018_parameter_values() {
         assert_eq!(VECTOR_ROOT_E131_DATA, 0x0000_0004);

--- a/src/receive.rs
+++ b/src/receive.rs
@@ -99,7 +99,7 @@ const DEFAULT_MERGE_FUNC: fn(&DMXData, &DMXData) -> Result<DMXData> =
 pub struct DMXData {
     /// The universe that the data was sent to.
     pub universe: u16,
-    
+
     /// The actual universe data, if less than 512 values in length then implies trailing 0's to pad to a full-universe of data.
     pub values: Vec<u8>,
 
@@ -124,26 +124,26 @@ pub struct DMXData {
 }
 
 /// Allows receiving dmx or other (different startcode) data using sacn.
-/// 
+///
 /// # Examples
 ///
 /// ```
 /// // Example showing creation of a receiver and receiving some data, as there is no sender this receiver then handles the timeout.
 /// use sacn::receive::SacnReceiver;
 /// use sacn::packet::ACN_SDT_MULTICAST_PORT;
-/// 
+///
 /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 /// use std::time::Duration;
-/// 
+///
 /// const UNIVERSE1: u16 = 1;
 /// const TIMEOUT: Option<Duration> = Some(Duration::from_secs(1)); // A timeout of None means blocking behaviour, some indicates the actual timeout.
-/// 
+///
 /// let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), ACN_SDT_MULTICAST_PORT);
 ///
 /// let mut dmx_rcv = SacnReceiver::with_ip(addr, None).unwrap();
 ///
 /// dmx_rcv.listen_universes(&[UNIVERSE1]).unwrap();
-/// 
+///
 /// match dmx_rcv.recv(TIMEOUT) {
 ///     Err(e) => {
 ///         // Print out the error.
@@ -1960,10 +1960,10 @@ fn check_seq_number(
         None => {
             // Previously checked that cid is present (and added if not), if None is returned now it indicates that between that check and this
             // function the cid key value has been removed. This can only happen if there is a memory corruption/thread-interleaving or similar external
-            // event which the receiver cannot be expected to handle / doesn't support. 
+            // event which the receiver cannot be expected to handle / doesn't support.
             // The rust typing system forces this possibility to be acknowledged when in some languages this possibility would still exist but it would be hidden
-            // within the code. 
-            // While a panic!() call here isn't ideal it shows the strength in the explictness of the rust system and points to an area of 
+            // within the code.
+            // While a panic!() call here isn't ideal it shows the strength in the explictness of the rust system and points to an area of
             // potential later improvement within the code by not hiding the problem. As normal if the panic must be caught then rust allows this later on by utilising
             // a mechanism such as catch unwind https://doc.rust-lang.org/std/panic/fn.catch_unwind.html.
             // Another possibility here could be to retry the method but this could end with an infinite loop.
@@ -2659,7 +2659,11 @@ mod test {
                 assert!(false, "Receiver incorrectly accepted third data packet");
             }
             Err(e) => {
-                assert!(false, "Receiver correctly rejected third data packet but with unexpected error: {}", e);
+                assert!(
+                    false,
+                    "Receiver correctly rejected third data packet but with unexpected error: {}",
+                    e
+                );
             }
         }
     }
@@ -2746,7 +2750,7 @@ mod test {
                         assert!(
                             false,
                             "Data packet with sequence number: {} was rejected incorrectly",
-                                i
+                            i
                         );
                     }
                 }
@@ -2755,8 +2759,8 @@ mod test {
                     if (diff <= REJECT_RANGE_UPPER_BOUND) && (diff > REJECT_RANGE_LOWER_BOUND) {
                         assert!(
                             false,
-                            "Data packet with sequence number: {} was accepted incorrectly", 
-                                1
+                            "Data packet with sequence number: {} was accepted incorrectly",
+                            1
                         );
                     } else {
                         assert!(
@@ -2937,7 +2941,11 @@ mod test {
                 assert!(false, "Receiver incorrectly accepted third sync packet");
             }
             Err(e) => {
-                assert!(false, "Receiver correctly rejected third sync packet but with unexpected error: {}", e);
+                assert!(
+                    false,
+                    "Receiver correctly rejected third sync packet but with unexpected error: {}",
+                    e
+                );
             }
         }
     }
@@ -2945,9 +2953,9 @@ mod test {
     /// Creates a receiver and then makes it handle 2 sync packets with sequence numbers 0 and 1 respectively.
     /// The receiver then resets the sequence number counters and then handles a sync packet with sequence number 0. This would normally be rejected
     /// as per test_sync_packet_sequence_number_below_expected but because of the reset it shouldn't be.
-    /// 
+    ///
     /// This checks that the sync packet sequence numbers are reset correctly.
-    /// 
+    ///
     #[test]
     fn test_sync_packet_sequence_number_reset() {
         const UNIVERSE1: u16 = 1;
@@ -2998,9 +3006,9 @@ mod test {
     /// Creates a receiver and then makes it handle 2 data packets with sequence numbers 0 and 1 respectively.
     /// The receiver then resets the sequence number counters and then handles a data packet with sequence number 0. This would normally be rejected
     /// as per test_data_packet_sequence_number_below_expected but because of the reset it shouldn't be.
-    /// 
+    ///
     /// This checks that the data packet sequence numbers are reset correctly.
-    /// 
+    ///
     #[test]
     fn test_data_packet_sequence_number_reset() {
         const UNIVERSE1: u16 = 1;
@@ -3218,25 +3226,24 @@ mod test {
         let source_limit: Option<usize> = Some(0);
 
         match SacnReceiver::with_ip(addr, source_limit) {
-            Err(e) => {
-                match e.kind() {
-                    ErrorKind::Io(x) => {
-                        match x.kind() {
-                            std::io::ErrorKind::InvalidInput => {
-                                assert!(true, "Correct error returned");
-                            }
-                            _ => {
-                                assert!(false, "Expected error returned");
-                            }
-                        }
+            Err(e) => match e.kind() {
+                ErrorKind::Io(x) => match x.kind() {
+                    std::io::ErrorKind::InvalidInput => {
+                        assert!(true, "Correct error returned");
                     }
                     _ => {
-                        assert!(false, "Unexpected error type returned");
+                        assert!(false, "Expected error returned");
                     }
+                },
+                _ => {
+                    assert!(false, "Unexpected error type returned");
                 }
-            }
+            },
             _ => {
-                assert!(false, "SacnReceiver accepted 0 source limit when it shouldn't");
+                assert!(
+                    false,
+                    "SacnReceiver accepted 0 source limit when it shouldn't"
+                );
             }
         }
     }
@@ -3246,7 +3253,10 @@ mod test {
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), ACN_SDT_MULTICAST_PORT);
         let dmx_rcv = SacnReceiver::with_ip(addr, None).unwrap();
 
-        assert!(dmx_rcv.is_multicast_enabled(), "Multicast not enabled by default");
+        assert!(
+            dmx_rcv.is_multicast_enabled(),
+            "Multicast not enabled by default"
+        );
     }
 
     #[test]
@@ -3256,7 +3266,10 @@ mod test {
 
         dmx_rcv.set_is_multicast_enabled(false).unwrap();
 
-        assert!(!dmx_rcv.is_multicast_enabled(), "Multicast not disabled correctly");
+        assert!(
+            !dmx_rcv.is_multicast_enabled(),
+            "Multicast not disabled correctly"
+        );
     }
 
     #[test]
@@ -3268,7 +3281,7 @@ mod test {
 
         let data: DMXData = DMXData {
             universe: 0,
-            values: vec![1,2,3],
+            values: vec![1, 2, 3],
             sync_uni: SYNC_ADDR,
             priority: 100,
             src_cid: Some(Uuid::new_v4()),
@@ -3280,7 +3293,11 @@ mod test {
 
         dmx_rcv.clear_all_waiting_data();
 
-        assert_eq!(dmx_rcv.rtrv_waiting_data(SYNC_ADDR), Vec::new(), "Data was not reset as expected");
+        assert_eq!(
+            dmx_rcv.rtrv_waiting_data(SYNC_ADDR),
+            Vec::new(),
+            "Data was not reset as expected"
+        );
     }
 
     #[test]
@@ -3288,7 +3305,10 @@ mod test {
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), ACN_SDT_MULTICAST_PORT);
         let dmx_rcv = SacnReceiver::with_ip(addr, None).unwrap();
 
-        assert!(!dmx_rcv.get_announce_source_discovery(), "Announce source discovery is true by default when should be false");
+        assert!(
+            !dmx_rcv.get_announce_source_discovery(),
+            "Announce source discovery is true by default when should be false"
+        );
     }
 
     #[test]
@@ -3296,7 +3316,10 @@ mod test {
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), ACN_SDT_MULTICAST_PORT);
         let dmx_rcv = SacnReceiver::with_ip(addr, None).unwrap();
 
-        assert!(!dmx_rcv.get_announce_timeout(), "Announce timeout flag is true by default when should be false");
+        assert!(
+            !dmx_rcv.get_announce_timeout(),
+            "Announce timeout flag is true by default when should be false"
+        );
     }
 
     #[test]
@@ -3304,7 +3327,10 @@ mod test {
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), ACN_SDT_MULTICAST_PORT);
         let dmx_rcv = SacnReceiver::with_ip(addr, None).unwrap();
 
-        assert!(!dmx_rcv.get_announce_stream_termination(), "Announce termination flag is true by default when should be false");
+        assert!(
+            !dmx_rcv.get_announce_stream_termination(),
+            "Announce termination flag is true by default when should be false"
+        );
     }
 
     /// Tests handling a sync packet for a synchronisation address which isn't currently being listened to.
@@ -3313,10 +3339,15 @@ mod test {
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), ACN_SDT_MULTICAST_PORT);
         let mut dmx_rcv = SacnReceiver::with_ip(addr, None).unwrap();
 
-        let res = dmx_rcv.handle_sync_packet(Uuid::new_v4(), SynchronizationPacketFramingLayer{
-            sequence_number: 0,
-            synchronization_address: 1
-        }).unwrap(); // Checks that no error is produced.
+        let res = dmx_rcv
+            .handle_sync_packet(
+                Uuid::new_v4(),
+                SynchronizationPacketFramingLayer {
+                    sequence_number: 0,
+                    synchronization_address: 1,
+                },
+            )
+            .unwrap(); // Checks that no error is produced.
 
         assert_eq!(res, None, "Sync packet produced output when should have been ignored as for an address that isn't being listened to");
     }
@@ -3325,7 +3356,7 @@ mod test {
     #[test]
     fn test_dmx_data_eq() {
         const UNIVERSE: u16 = 1;
-        let values: Vec<u8> = vec!(1,2,3);
+        let values: Vec<u8> = vec![1, 2, 3];
         const SYNC_ADDR: u16 = 1;
         const PRIORITY: u8 = 100;
         const PREVIEW: bool = false;
@@ -3341,7 +3372,7 @@ mod test {
             preview: PREVIEW,
             recv_timestamp: Instant::now(),
         };
-        
+
         let data2 = DMXData {
             universe: UNIVERSE,
             values: values,
@@ -3354,6 +3385,9 @@ mod test {
             recv_timestamp: Instant::now(),
         };
 
-        assert_eq!(data1, data2, "DMX data not seen as equivalent when should be");
+        assert_eq!(
+            data1, data2,
+            "DMX data not seen as equivalent when should be"
+        );
     }
 }

--- a/src/sacn_parse_pack_error.rs
+++ b/src/sacn_parse_pack_error.rs
@@ -8,15 +8,15 @@
 // This file was created as part of a University of St Andrews Computer Science BSC Senior Honours Dissertation Project.
 
 /// The errors used within the SacnLibrary specifically those related to parsing and packeting packets received/sent on the network.
-/// 
+///
 pub mod sacn_parse_pack_error {
     error_chain! {
-        errors {   
+        errors {
             /// When parsing packet invalid data encountered.
-            /// 
+            ///
             /// # Arguments
             /// msg: A message providing further details (if any) as to what data was invalid.
-            /// 
+            ///
             ParseInvalidData(msg: String) {
                 description("Data provided to parse into a packet is invalid"),
                 display("Error when parsing data into packet, msg: {}", msg)
@@ -24,20 +24,20 @@ pub mod sacn_parse_pack_error {
 
             /// Attempted to parse a priority value that is outwith the allowed range of [0, E131_MAX_PRIORITY].
             /// As per ANSI E1.31-2018 Section 6.2.3
-            /// 
+            ///
             /// # Arguments
             /// msg: A message providing further details (if any) as to why the priority valid was invalid.
-            /// 
+            ///
             ParseInvalidPriority(msg: String) {
                 description("Attempted to parse a priority value that is outwith the allowed range of [0, 200]"),
                 display("Attempted to parse a priority value that is outwith the allowed range of [0, 200], msg: {}", msg)
             }
 
             /// Attempted to parse a page value that is invalid - e.g. the page value is higher than the last_page value.
-            /// 
+            ///
             /// # Arguments
             /// msg: A message providing further details (if any) as to why the page was invalid.
-            /// 
+            ///
             ParseInvalidPage(msg: String) {
                 description("Attempted to parse a page value that is invalid"),
                 display("Error when parsing page value, msg: {}", msg)
@@ -45,10 +45,10 @@ pub mod sacn_parse_pack_error {
 
             /// Attempted to parse a sync address value that is outwith the allowed range of [0, E131_MAX_MULTICAST_UNIVERSE].
             /// As per ANSI E1.31-2018 Section 9.1.1.
-            /// 
+            ///
             /// # Arguments
             /// msg: A message providing further details (if any) as to why the synchronisation address was invalid.
-            /// 
+            ///
             ParseInvalidSyncAddr(msg: String) {
                 description("Attempted to parse a sync_addr value that is outwith the allowed range of [0, 63999]"),
                 display("Attempted to parse a sync_addr value that is outwith the allowed range of [0, 63999], msg: {}", msg)
@@ -56,10 +56,10 @@ pub mod sacn_parse_pack_error {
 
             /// Attempted to parse a universe value that is outwith the allowed range of [1, E131_MAX_MULTICAST_UNIVERSE].
             /// As per ANSI E1.31-2018 Section 9.1.1.
-            /// 
+            ///
             /// # Arguments
             /// msg: A message providing further details (if any) as to why the universe field was invalid.
-            /// 
+            ///
             ParseInvalidUniverse(msg: String) {
                 description("Attempted to parse a universe value that is outwith the allowed range of [1, 63999]"),
                 display("Attempted to parse a universe value that is outwith the allowed range of [1, 63999], msg: {}", msg)
@@ -67,100 +67,100 @@ pub mod sacn_parse_pack_error {
 
             /// Attempted to parse a packet with an invalid ordering of universes.
             /// For example a discovery packet where the universes aren't correctly ordered in assending order.
-            /// 
+            ///
             /// # Arguments
             /// msg: A message providing further details (if any) as to why the universe ordering was invalid.
-            /// 
+            ///
             ParseInvalidUniverseOrder(msg: String) {
                 description("Attempted to parse a packet with an invalid ordering of universes"),
                 display("Attempted to parse a packet with an invalid ordering of universes, msg: {}", msg)
             }
 
             /// When packing a packet into a buffer invalid data encountered.
-            /// 
+            ///
             /// # Arguments
             /// msg: A message providing further details (if any) as to why the data couldn't be packed.
-            /// 
+            ///
             PackInvalidData(msg: String) {
                 description("When packing a packet into a buffer invalid data encountered"),
                 display("When packing a packet into a buffer invalid data encountered, msg: {}", msg)
             }
 
             /// Supplied buffer is not large enough to pack packet into.
-            /// 
+            ///
             /// # Arguments
             /// msg: A message providing further details (if any) as to why the pack buffer is insufficient.
-            /// 
+            ///
             PackBufferInsufficient(msg: String) {
                 description("Supplied buffer is not large enough to pack packet into"),
                 display("Supplied buffer is not large enough to pack packet into, msg: {}", msg)
             }
 
             /// Supplied buffer does not contain enough data.
-            /// 
+            ///
             /// # Arguments
             /// msg: A message providing further details (if any) as to why there was insufficient data for parsing.
-            /// 
+            ///
             ParseInsufficientData(msg: String) {
                 description("Supplied buffer does not contain enough data"),
                 display("Supplied buffer does not contain enough data, msg: {}", msg)
             }
 
             /// Received PDU flags are invalid for parsing.
-            /// 
+            ///
             /// # Arguments
             /// flags: The flags that were found which are invalid.
-            /// 
+            ///
             ParsePduInvalidFlags(flags: u8) {
                 description("Received PDU flags are invalid"),
                 display("PDU Flags {:#b} are invalid for parsing", flags)
             }
 
             /// Received PDU length is invalid.
-            /// 
+            ///
             /// # Arguments
             /// len: The length provided in the Pdu which is invalid.
-            /// 
+            ///
             PduInvalidLength(len: usize) {
                 description("Received PDU length is invalid"),
                 display("PDU Length {} is invalid", len)
             }
 
             /// Received PDU vector is invalid/unsupported by this library.
-            /// 
+            ///
             /// # Arguments
             /// vec: The vector parsed which is invalid / cannot be used.
-            /// 
+            ///
             PduInvalidVector(vec: u32) {
                 description("Received PDU vector is invalid/unsupported by this library"),
                 display("Vector {:#x} not supported", vec)
             }
 
             /// Error parsing the received UUID.
-            /// 
+            ///
             /// # Arguments
             /// msg: A message providing further details (if any) as to why the uuid (used for CID) couldn't be parsed.
-            /// 
+            ///
             UuidError(msg: String) {
                 description("Error parsing the received UUID"),
                 display("Error parsing the received UUID, msg: {}", msg)
             }
 
             /// Error parsing received UTF8 string.
-            /// 
+            ///
             /// # Arguments
             /// msg: A message providing further details (if any) as to why the string couldn't be parsed.
-            /// 
+            ///
             Utf8Error(msg: String) {
                 description("Error parsing received UTF8 string"),
                 display("Error parsing received UTF8 string, msg: {}", msg)
             }
 
             /// Source name in packet was invalid, for example due to not being null terminated.
-            /// 
+            ///
             /// # Arguments
             /// msg: A message providing further details (if any) as to why the source name was invalid.
-            /// 
+            ///
             SourceNameInvalid(msg: String) {
                 description("Attempted to parse invalid source name"),
                 display("Attempted to parse invalid source name, msg: {}", msg)

--- a/src/source.rs
+++ b/src/source.rs
@@ -9,35 +9,35 @@
 //
 // This file was modified as part of a University of St Andrews Computer Science BSC Senior Honours Dissertation Project.
 //
-// Documentation of private or crate local items that effects public items, such as errors from private functions which get passed up to a 
+// Documentation of private or crate local items that effects public items, such as errors from private functions which get passed up to a
 // public function, should be copied into the documentation of the public item so that the public facing documentation is a complete documentation
 // of each public item without relying on referring to private items.
 //
 
-use error::errors::{*};
+use error::errors::*;
 use packet::*;
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::cmp;
 use std::cmp::min;
-use std::time::{Duration, Instant};
-use std::thread::{JoinHandle};
-use std::thread;
-use std::sync::{Arc, MutexGuard, Mutex};
+use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::thread;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
 /// Socket2 used to create the underlying UDP socket that sACN is sent on.
-use socket2::{Socket, Domain, Type};
+use socket2::{Domain, Socket, Type};
 
 /// UUID library used to handle the UUID's used in the CID fields.
 use uuid::Uuid;
 
 /// The name of the thread which runs periodically to perform various actions such as universe discovery adverts for the source.
-const SND_UPDATE_THREAD_NAME: &'static str = "rust_sacn_snd_update_thread"; 
+const SND_UPDATE_THREAD_NAME: &'static str = "rust_sacn_snd_update_thread";
 
 /// The default startcode used to send stream termination packets when the SacnSource is closed.
-const DEFAULT_TERMINATE_START_CODE: u8 = 0; 
+const DEFAULT_TERMINATE_START_CODE: u8 = 0;
 
 /// The poll rate of the update thread.
 /// Discovery updates are sent every E131_UNIVERSE_DISCOVERY_INTERVAL so the poll rate must be lower than or equal to this.
@@ -81,9 +81,9 @@ pub struct SacnSource {
     /// Protected by a Mutex lock to allow concurrent access between user threads and the update thread below.
     internal: Arc<Mutex<SacnSourceInternal>>,
 
-    /// Update thread which performs actions every DEFAULT_POLL_PERIOD such as checking if a universe 
+    /// Update thread which performs actions every DEFAULT_POLL_PERIOD such as checking if a universe
     /// discovery packet should be sent.
-    update_thread: Option<JoinHandle<()>>
+    update_thread: Option<JoinHandle<()>>,
 }
 
 /// Internal sACN sender, this does most of the work however is encapsulated within SacnSource
@@ -103,7 +103,7 @@ struct SacnSourceInternal {
     /// The human readable name of this source.
     name: String,
 
-    /// Flag which is included in sACN packets to indicate that the data shouldn't be used for live output 
+    /// Flag which is included in sACN packets to indicate that the data shouldn't be used for live output
     /// (ie. on actual lighting fixtures). A receiver may or may not be compliant with this so it should not be relied
     /// upon in an untested environment.
     preview_data: bool,
@@ -116,10 +116,10 @@ struct SacnSourceInternal {
     /// Sequence numbers are always in the range [0, 255].
     sync_sequences: RefCell<HashMap<u16, u8>>,
 
-    /// A list of the universes registered to send by this source, used for universe discovery. 
+    /// A list of the universes registered to send by this source, used for universe discovery.
     /// Always sorted with lowest universe first to allow quicker usage.
     /// This may never contain duplicate universe values.
-    universes: Vec<u16>, 
+    universes: Vec<u16>,
 
     /// Flag that indicates if the SacnSourceInternal is running (the update thread should be triggering periodic discovery packets).
     running: bool,
@@ -134,7 +134,7 @@ struct SacnSourceInternal {
 impl SacnSource {
     /// Constructs a new SacnSource with the given name, binding to an IPv4 address.
     /// This generates a new CID automatically using random values.
-    /// 
+    ///
     /// # Errors
     /// See (with_cid_ip)[with_cid_ip]
     pub fn new_v4(name: &str) -> Result<SacnSource> {
@@ -143,17 +143,20 @@ impl SacnSource {
     }
 
     /// Constructs a new SacnSource with the given name and specified CID binding to an IPv4 address.
-    /// 
+    ///
     /// # Errors
     /// See (with_cid_ip)[with_cid_ip]
     pub fn with_cid_v4(name: &str, cid: Uuid) -> Result<SacnSource> {
-        let ip = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), ACN_SDT_MULTICAST_PORT);
+        let ip = SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            ACN_SDT_MULTICAST_PORT,
+        );
         SacnSource::with_cid_ip(name, cid, ip)
     }
 
     /// Constructs a new SacnSource with the given name, binding to an IPv6 address.
     /// By default this will only receive IPv6 data but IPv4 can also be enabled by calling set_ipv6_only(false).
-    /// 
+    ///
     /// # Errors
     /// See (with_cid_ip)[with_cid_ip]
     pub fn new_v6(name: &str) -> Result<SacnSource> {
@@ -162,16 +165,19 @@ impl SacnSource {
     }
 
     /// Constructs a new SacnSource with the given name and specified CID binding to an IPv6 address.
-    /// 
+    ///
     /// # Errors
     /// See (with_cid_ip)[with_cid_ip]
     pub fn with_cid_v6(name: &str, cid: Uuid) -> Result<SacnSource> {
-        let ip = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)), ACN_SDT_MULTICAST_PORT);
+        let ip = SocketAddr::new(
+            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
+            ACN_SDT_MULTICAST_PORT,
+        );
         SacnSource::with_cid_ip(name, cid, ip)
     }
 
     /// Constructs a new SacnSource with the given name and binding to the supplied ip.
-    /// 
+    ///
     /// # Errors
     /// See (with_cid_ip)[with_cid_ip]
     pub fn with_ip(name: &str, ip: SocketAddr) -> Result<SacnSource> {
@@ -179,18 +185,20 @@ impl SacnSource {
     }
 
     /// Constructs a new SacnSource with the given name, cid and binding to the supplied ip.
-    /// 
+    ///
     /// # Errors
-    /// Io: Returned if the underlying UDP socket cannot be created and bound or if the thread used for sending periodic 
+    /// Io: Returned if the underlying UDP socket cannot be created and bound or if the thread used for sending periodic
     ///     discovery adverts fails to be created. Causes can be distinguished by looking at the error chain.
-    /// 
+    ///
     /// UnsupportedIpVersion: Returned if the SocketAddr is not IPv4 or IPv6.
-    /// 
+    ///
     /// MalformedSourceName: Returned if the given source name is longer than the maximum allowed size of E131_SOURCE_NAME_FIELD_LENGTH.
-    /// 
+    ///
     pub fn with_cid_ip(name: &str, cid: Uuid, ip: SocketAddr) -> Result<SacnSource> {
         if name.len() > E131_SOURCE_NAME_FIELD_LENGTH {
-            bail!(ErrorKind::MalformedSourceName("Source name provided is longer than maximum allowed".to_string()));
+            bail!(ErrorKind::MalformedSourceName(
+                "Source name provided is longer than maximum allowed".to_string()
+            ));
         }
 
         let trd_builder = thread::Builder::new().name(SND_UPDATE_THREAD_NAME.into());
@@ -199,7 +207,7 @@ impl SacnSource {
 
         let mut trd_src = internal_src.clone();
 
-        let src = SacnSource { 
+        let src = SacnSource {
             internal: internal_src,
             update_thread: Some(trd_builder.spawn(move || {
                 while trd_src.lock().unwrap().running {
@@ -208,11 +216,10 @@ impl SacnSource {
                         Err(e) => {
                             println!("Periodic error: {:?}", e);
                         }
-                        
+
                         _ => {
                             // In-case of an error on the discovery thread the source continues to operate and tries again.
                             // As no unsafe code blocks are used the rust compiler guarantees this is memory safe.
-                            
                         }
                     }
                 }
@@ -223,192 +230,205 @@ impl SacnSource {
     }
 
     /// Registers the given universes on this source in addition to already registered universes.
-    /// 
-    /// This allows sending data to those universes or using them as synchronisation addresses as well as adding them to 
-    /// the list of universes that appear in universe discovery packets that are sent (depending on the 
-    /// set_is_sending_discovery flag) periodically. 
-    /// 
+    ///
+    /// This allows sending data to those universes or using them as synchronisation addresses as well as adding them to
+    /// the list of universes that appear in universe discovery packets that are sent (depending on the
+    /// set_is_sending_discovery flag) periodically.
+    ///
     /// This is more efficient than repeated calls to register_universe as it means only 1 mutex unlock is required.
-    /// 
+    ///
     /// # Arguments
     /// universes: The sACN universes to register for usage as data universes and/or synchronisation addresses. Note that sACN
     ///     universes start at 1 not 0.
-    /// 
+    ///
     /// # Errors
-    /// IllegalUniverse: Returned if a universe is outwith the range permitted by ANSI E1.31-2018. 
-    /// 
+    /// IllegalUniverse: Returned if a universe is outwith the range permitted by ANSI E1.31-2018.
+    ///
     /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-    /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-    /// 
+    /// a panic while accessing causing the source to be left in a potentially inconsistent state.
+    ///
     pub fn register_universes(&mut self, universes: &[u16]) -> Result<()> {
         unlock_internal_mut(&mut self.internal)?.register_universes(universes)
     }
 
     /// Registers a single universe on this source in addition to already registered universes.
-    /// 
-    /// This allows sending data to those universes or using them as synchronisation addresses as well as adding them to 
-    /// the list of universes that appear in universe discovery packets that are sent (depending on the 
-    /// set_is_sending_discovery flag) periodically. 
-    /// 
+    ///
+    /// This allows sending data to those universes or using them as synchronisation addresses as well as adding them to
+    /// the list of universes that appear in universe discovery packets that are sent (depending on the
+    /// set_is_sending_discovery flag) periodically.
+    ///
     /// If registering multiple universes see (register_universes)[register_universes].
-    /// 
+    ///
     /// # Arguments
     /// universe: The sACN universe to register for usage as a data universe and/or synchronisation address. Note that sACN
     ///     universes start at 1 not 0.
-    /// 
+    ///
     /// # Errors
-    /// IllegalUniverse: Returned if the universe is outwith the range permitted by ANSI E1.31-2018. 
-    /// 
+    /// IllegalUniverse: Returned if the universe is outwith the range permitted by ANSI E1.31-2018.
+    ///
     /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-    /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-    /// 
+    /// a panic while accessing causing the source to be left in a potentially inconsistent state.
+    ///
     pub fn register_universe(&mut self, universe: u16) -> Result<()> {
         unlock_internal_mut(&mut self.internal)?.register_universe(universe)
     }
 
     /// Sends the given data to the given universes with the given priority, synchronisation address (universe) and destination ip.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// universe:     The sACN universes that the data should be set on, the data will be split over these universes with each UNIVERSE_CHANNEL_CAPACITY
     ///                 sized chunk sent to the next universe.
-    /// 
+    ///
     /// data:         The data that should be sent, must have a length greater than 0.
-    /// 
-    /// priority:     The E131 priority that the data should be sent with, must be less than E131_MAX_PRIORITY (const.E131_MAX_PRIORITY.packet), 
+    ///
+    /// priority:     The E131 priority that the data should be sent with, must be less than E131_MAX_PRIORITY (const.E131_MAX_PRIORITY.packet),
     ///                 if a value of None is provided then the default of E131_DEFAULT_PRIORITY (const.E131_DEFAULT_PRIORITY.packet) is used.
-    /// 
+    ///
     /// dst_ip:       The destination IP, can be Ipv4 or Ipv6, None if should be sent using ip multicast.
-    /// 
+    ///
     /// sync_address: The address to use for synchronisation, must be a valid universe, None indicates no synchronisation. If synchronisation is required a
     ///                 reasonable default address to use is the first universe that this data is being sent to.
-    /// 
-    /// As per ANSI E1.31-2018 Section 6.6.1 this method shouldn't be called at a higher refresher rate than specified in ANSI E1.11 [DMX] unless 
+    ///
+    /// As per ANSI E1.31-2018 Section 6.6.1 this method shouldn't be called at a higher refresher rate than specified in ANSI E1.11 [DMX] unless
     ///     configured by the user to do so in an environment which doesn't contain any E1.31 to DMX512-A converters.
-    /// 
+    ///
     /// Note as per ANSI-E1.31-2018 Appendix B.1 it is recommended to have a small delay before sending the follow up sync packet.
-    /// 
+    ///
     /// # Errors
     /// SenderAlreadyTerminated: Returned if this method is called on an SacnReceiverInternal that has already terminated.
-    /// 
+    ///
     /// InvalidInput: Returned if the data array has length 0 or if an insufficient number of universes for the given data are provided (each universe takes 513 bytes of data).
-    /// 
+    ///
     /// InvalidPriority: Returned if the priority is greater than the allowed maximum priority of E131_MAX_PRIORITY.
-    /// 
+    ///
     /// IllegalUniverse: Returned if the universe is outwith the allowed range as specified by ANSI E1.31-2018 Section 6.2.7.
-    /// 
+    ///
     /// UniverseNotRegistered: Returned if the universe is not registered on the given SacnSourceInternal.
-    /// 
+    ///
     /// ExceedUniverseCapacity: Returned if the data has a length greater than the maximum allowed within a universe (packet::UNIVERSE_CHANNEL_CAPACITY).
-    /// 
+    ///
     /// Io: Returned if the data fails to be sent on the socket, see send_to(fn.send_to.Socket).
-    /// 
+    ///
     /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-    /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-    /// 
-    pub fn send(&mut self, universes: &[u16], data: &[u8], priority: Option<u8>, dst_ip: Option<SocketAddr>, synchronisation_addr: Option<u16>) -> Result<()> {
-        unlock_internal_mut(&mut self.internal)?.send(universes, data, priority, dst_ip, synchronisation_addr)
+    /// a panic while accessing causing the source to be left in a potentially inconsistent state.
+    ///
+    pub fn send(
+        &mut self,
+        universes: &[u16],
+        data: &[u8],
+        priority: Option<u8>,
+        dst_ip: Option<SocketAddr>,
+        synchronisation_addr: Option<u16>,
+    ) -> Result<()> {
+        unlock_internal_mut(&mut self.internal)?.send(
+            universes,
+            data,
+            priority,
+            dst_ip,
+            synchronisation_addr,
+        )
     }
 
     /// Sends a synchronisation packet to trigger the sending of packets waiting to be sent together.
-    /// 
-    /// A common pattern would be to use the send method to send data to all the universes that should be synchronised using a 
-    /// chosen synchronisation universe then wait for a small time as per the recommendation in ANSI-E1.31-2018 Appendix B.1 and 
+    ///
+    /// A common pattern would be to use the send method to send data to all the universes that should be synchronised using a
+    /// chosen synchronisation universe then wait for a small time as per the recommendation in ANSI-E1.31-2018 Appendix B.1 and
     /// then send a synchronisation packet with the address of the synchronisation universe chosen to trigger the packets.
-    /// 
+    ///
     /// # Arguments
     /// universe: The universe of this synchronisation packet.
     /// dst_ip:   The destination IP address for this packet or None if it should be sent using multicast.
-    /// 
+    ///
     /// # Errors
     /// IllegalUniverse: Returned if the universe is outwith the allowed range of sACN universes as defined in ANSI E1.31-2018 Section 6.2.7.
-    /// 
+    ///
     /// UniverseNotRegistered: Returned if the universe is not registered on the given SacnSourceInternal.
-    /// 
+    ///
     /// Io: Returned if the packet fails to be sent using the underlying network socket.
-    /// 
+    ///
     /// SacnParsePackError: Returned if the sync packet fails to be packed.
-    /// 
+    ///
     /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-    /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-    /// 
+    /// a panic while accessing causing the source to be left in a potentially inconsistent state.
+    ///
     pub fn send_sync_packet(&mut self, universe: u16, dst_ip: Option<SocketAddr>) -> Result<()> {
         unlock_internal_mut(&mut self.internal)?.send_sync_packet(universe, dst_ip)
     }
 
     /// Terminates sending on the given universe.
-    /// 
+    ///
     /// # Errors:
     /// IllegalUniverse: Returned if the universe is outwith the allowed range of sACN universes as defined in ANSI E1.31-2018 Section 6.2.7.
-    /// 
+    ///
     /// UniverseNotRegistered: Returned if the universe is not registered on this source.
-    /// 
+    ///
     /// Io: Returned if the termination packets fail to be sent on the socket.
-    /// 
+    ///
     /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-    /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-    /// 
+    /// a panic while accessing causing the source to be left in a potentially inconsistent state.
+    ///
     pub fn terminate_stream(&mut self, universe: u16, start_code: u8) -> Result<()> {
         unlock_internal_mut(&mut self.internal)?.terminate_stream(universe, start_code)
     }
 
     /// Returns the ACN CID device identifier of the SacnSourceInternal.
-    /// 
+    ///
     /// # Errors
     /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-    /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-    /// 
+    /// a panic while accessing causing the source to be left in a potentially inconsistent state.
+    ///
     pub fn cid(&self) -> Result<Uuid> {
         Ok(*unlock_internal(&self.internal)?.cid())
     }
 
     /// Sets the ACN CID device identifier.
-    /// 
+    ///
     /// # Arguments
     /// cid: The new CID identifier for this source. It is left to the user to ensure that this is always unique within the network the source is in.
-    /// 
+    ///
     /// # Errors
     /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-    /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-    /// 
+    /// a panic while accessing causing the source to be left in a potentially inconsistent state.
+    ///
     pub fn set_cid(&mut self, cid: Uuid) -> Result<()> {
         unlock_internal_mut(&mut self.internal)?.set_cid(cid);
         Ok(())
     }
 
     /// Returns the ACN source name.
-    /// 
+    ///
     /// # Errors
     /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-    /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-    /// 
+    /// a panic while accessing causing the source to be left in a potentially inconsistent state.
+    ///
     pub fn name(&self) -> Result<String> {
         Ok(unlock_internal(&self.internal)?.name().into())
     }
 
     /// Sets ACN source name.
-    /// 
+    ///
     /// # Argument
     /// name: The new name for the source, it is left to the user to ensure this is unique within the sACN network.
-    /// 
+    ///
     /// # Errors
     /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-    /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-    /// 
+    /// a panic while accessing causing the source to be left in a potentially inconsistent state.
+    ///
     /// MalformedSourceName: Returned to indicate that the given source name is longer than the maximum allowed as per E131_SOURCE_NAME_FIELD_LENGTH.
-    /// 
+    ///
     pub fn set_name(&mut self, name: &str) -> Result<()> {
         unlock_internal_mut(&mut self.internal)?.set_name(name)
     }
 
     /// Returns true if SacnSourceInternal is in preview mode, false if not.
-    /// 
+    ///
     /// For details of preview_mode see (set_preview_mode)[set_preview_mode].
-    /// 
+    ///
     /// # Errors
     /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-    /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-    /// 
+    /// a panic while accessing causing the source to be left in a potentially inconsistent state.
+    ///
     pub fn preview_mode(&self) -> Result<bool> {
         Ok(unlock_internal(&self.internal)?.preview_mode())
     }
@@ -418,105 +438,105 @@ impl SacnSource {
     /// # Arguments
     /// preview_mode: If true then all data packets from this SacnSource will have the Preview_Data flag set to true indicating that the data is not
     ///     for live output. If false then the flag will be set to false.
-    /// 
+    ///
     /// # Errors
     /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-    /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-    /// 
+    /// a panic while accessing causing the source to be left in a potentially inconsistent state.
+    ///
     pub fn set_preview_mode(&mut self, preview_mode: bool) -> Result<()> {
-       unlock_internal_mut(&mut self.internal)?.set_preview_mode(preview_mode);
-       Ok(())
+        unlock_internal_mut(&mut self.internal)?.set_preview_mode(preview_mode);
+        Ok(())
     }
 
     /// Sets the is_sending_discovery flag to the given value.
-    /// 
+    ///
     /// # Arguments
     /// val: The new value for the is_sending_discovery flag, if true then source will send periodic universe discovery packets
     /// and if false it won't.
-    /// 
+    ///
     pub fn set_is_sending_discovery(&mut self, val: bool) {
         self.internal.lock().unwrap().set_is_sending_discovery(val);
     }
 
     /// Returns the multicast time to live of the socket.
-    /// 
+    ///
     pub fn multicast_ttl(&self) -> Result<u32> {
         unlock_internal(&self.internal)?.multicast_ttl()
     }
 
     /// Sets the multicast time to live.
-    /// 
+    ///
     /// # Arguments
     /// multicast_ttl: The new time to live value for network packets sent using multicast.
-    /// 
+    ///
     /// # Errors
     /// Io: Returned if the multicast TTL fails to be set on the underlying socket.
-    /// 
+    ///
     /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-    /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-    /// 
+    /// a panic while accessing causing the source to be left in a potentially inconsistent state.
+    ///
     pub fn set_multicast_ttl(&mut self, multicast_ttl: u32) -> Result<()> {
         unlock_internal_mut(&mut self.internal)?.set_multicast_ttl(multicast_ttl)
     }
 
     /// Returns the current Time To Live for unicast packets send by this source.
-    /// 
+    ///
     /// # Errors
     /// Io: Returned if the TTL cannot be retrieved from the underlying socket.
-    /// 
+    ///
     /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-    /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-    /// 
+    /// a panic while accessing causing the source to be left in a potentially inconsistent state.
+    ///
     pub fn ttl(&self) -> Result<u32> {
         unlock_internal(&self.internal)?.ttl()
     }
 
     /// Sets the Time To Live for packets sent by this source.
-    /// 
+    ///
     /// # Arguments
     /// ttl: The new time to live value for new packets.
-    /// 
+    ///
     /// # Errors
     /// Io: Returned if the TTL value cannot be changed.
-    /// 
+    ///
     /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-    /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-    /// 
-    pub fn set_ttl(&mut self, ttl: u32) -> Result<()>{
+    /// a panic while accessing causing the source to be left in a potentially inconsistent state.
+    ///
+    pub fn set_ttl(&mut self, ttl: u32) -> Result<()> {
         unlock_internal_mut(&mut self.internal)?.set_ttl(ttl)
     }
 
     /// Sets if multicast loop is enabled.
-    /// 
+    ///
     /// # Arguments:
     /// multicast_loop: If true then multicast loop is enabled, if false it is not.
-    /// 
+    ///
     /// # Errors
     /// Io: Returned if the set_multicast_loop option fails to be set on the socket.
-    /// 
+    ///
     /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-    /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-    /// 
+    /// a panic while accessing causing the source to be left in a potentially inconsistent state.
+    ///
     pub fn set_multicast_loop_v4(&mut self, multicast_loop: bool) -> Result<()> {
         unlock_internal_mut(&mut self.internal)?.set_multicast_loop_v4(multicast_loop)
     }
 
     /// Returns true if multicast loop is enabled, false if not.
-    /// 
+    ///
     /// # Errors
     /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-    /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-    /// 
+    /// a panic while accessing causing the source to be left in a potentially inconsistent state.
+    ///
     pub fn multicast_loop(&self) -> Result<bool> {
         unlock_internal(&self.internal)?.multicast_loop()
     }
 
     /// Returns the universes currently registered on this source.
-    /// 
+    ///
     /// # Errors
     /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-    /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-    /// 
+    /// a panic while accessing causing the source to be left in a potentially inconsistent state.
+    ///
     pub fn universes(&self) -> Result<Vec<u16>> {
         Ok(unlock_internal(&self.internal)?.universes())
     }
@@ -524,18 +544,23 @@ impl SacnSource {
 
 /// By implementing the Drop trait for SacnSource it means that the user doesn't have to explicitly clean up the source
 /// and if it goes out of reference it will clean itself up and send the required termination packets etc.
-/// 
+///
 impl Drop for SacnSource {
-    fn drop(&mut self){
+    fn drop(&mut self) {
         match unlock_internal_mut(&mut self.internal) {
-            Ok(mut i) => { i.running = false; }
-            Err(_) => { return; } // As drop isn't always explicitly called and cannot return an error the error is ignored. Memory safety is maintain and this prevents causing a panic!.
+            Ok(mut i) => {
+                i.running = false;
+            }
+            Err(_) => {
+                return;
+            } // As drop isn't always explicitly called and cannot return an error the error is ignored. Memory safety is maintain and this prevents causing a panic!.
         };
 
         if let Some(thread) = self.update_thread.take() {
             {
-                match unlock_internal_mut(&mut self.internal) { // Internal is accessed twice separately, this allows the discovery thread to interleave between running being set to false speeding up termination.
-                    Ok(mut i) => { 
+                match unlock_internal_mut(&mut self.internal) {
+                    // Internal is accessed twice separately, this allows the discovery thread to interleave between running being set to false speeding up termination.
+                    Ok(mut i) => {
                         match i.terminate(DEFAULT_TERMINATE_START_CODE) {
                             _ => {} // For same reasons as above a potential error is ignored and a 'best attempt' is used to clean up.
                         }
@@ -550,29 +575,31 @@ impl Drop for SacnSource {
 
 impl SacnSourceInternal {
     /// Constructs a new SacnSourceInternal with DMX START code set to 0 with specified CID and binding IP address.
-    /// 
+    ///
     /// By default for an IPv6 address this will only receive IPv6 data but IPv4 can also be enabled by calling set_ipv6_only(false).
     /// By default the TTL for ipv4 packets is 1 to keep them within the local network.
-    /// 
+    ///
     /// # Arguments:
     /// name: The human readable name for this sacn source.
     /// cid:  The UUID for this source.
     /// ip:   The address that this source should bind to.
-    /// 
+    ///
     /// # Errors
     /// Io: Returned if the underlying socket cannot be created or the IP cannot be bound to the underlying socket. See (UdpBuilder::new_v4)[fn.new_v4.UdpBuilder], (UdpBuilder::new_v6)[fn.new_v6.UdpBuilder] and (Socket::bind)[fn.bind.Socket2].
-    /// 
+    ///
     /// UnsupportedIpVersion: Returned if the SockAddr is not IPv4 or IPv6.
-    /// 
+    ///
     fn with_cid_ip(name: &str, cid: Uuid, ip: SocketAddr) -> Result<SacnSourceInternal> {
         let socket = if ip.is_ipv4() {
             Socket::new(Domain::ipv4(), Type::dgram(), None).unwrap()
         } else if ip.is_ipv6() {
             Socket::new(Domain::ipv6(), Type::dgram(), None).unwrap()
         } else {
-            bail!(ErrorKind::UnsupportedIpVersion("Address to create SacnSource is not IPv4 or IPv6".to_string()));
+            bail!(ErrorKind::UnsupportedIpVersion(
+                "Address to create SacnSource is not IPv4 or IPv6".to_string()
+            ));
         };
-        
+
         // Multiple different processes might want to send to the sACN stream so therefore need to allow re-using the ACN port.
         // Set reuse port is only supported on linux.
         #[cfg(target_os = "linux")]
@@ -593,34 +620,34 @@ impl SacnSourceInternal {
             universes: Vec::new(),
             running: true,
             last_discovery_advert_timestamp: Instant::now(),
-            is_sending_discovery: true
+            is_sending_discovery: true,
         };
 
         Ok(ds)
     }
 
     /// Sets the is_sending_discovery flag to the given value.
-    /// 
+    ///
     /// If is_sending_discovery is set to false then no discovery adverts for this source
     /// will be sent otherwise (and by default) they will be sent every UNIVERSE_DISCOVERY_INTERVAL.
-    /// 
+    ///
     /// # Arguments:
     /// val: The new value of the is_sending_discovery flag.
-    /// 
+    ///
     fn set_is_sending_discovery(&mut self, val: bool) {
         self.is_sending_discovery = val;
     }
 
     /// Registers the given array of universes with this source.
-    /// 
+    ///
     /// Any universes already registered won't be re-registered and will have no effect.
-    /// 
+    ///
     /// # Arguments:
     /// universes: The sACN universe to register. Note that sACN universes start at 1 not 0.
-    /// 
+    ///
     /// # Errors
     /// See register_universe(fn.register_universe.source) for more details.
-    /// 
+    ///
     fn register_universes(&mut self, universes: &[u16]) -> Result<()> {
         for u in universes {
             self.register_universe(*u)?;
@@ -629,12 +656,12 @@ impl SacnSourceInternal {
     }
 
     /// Registers the given universe for sending with this source.
-    /// 
+    ///
     /// If a universe is already registered then this method has no effect.
-    /// 
+    ///
     /// # Errors
     /// IllegalUniverse: Returned if the universe is outwith the allowed range, see (is_universe_in_range)[fn.is_universe_in_range.packet].
-    /// 
+    ///
     fn register_universe(&mut self, universe: u16) -> Result<()> {
         is_universe_in_range(universe)?;
 
@@ -642,7 +669,8 @@ impl SacnSourceInternal {
             self.universes.push(universe);
         } else {
             match self.universes.binary_search(&universe) {
-                Err(i) => { // Value not found, i is the position it should be inserted
+                Err(i) => {
+                    // Value not found, i is the position it should be inserted
                     self.universes.insert(i, universe);
                 }
                 Ok(_) => {
@@ -654,20 +682,24 @@ impl SacnSourceInternal {
     }
 
     /// De-registers the given universe for sending with this source.
-    /// 
+    ///
     /// # Errors
     /// IllegalUniverse: Returned if the universe is outwith the allowed range, see (is_universe_in_range)[fn.is_universe_in_range.packet].
-    /// 
+    ///
     /// UniverseNotFound: Returned if the given universe was never registered originally.
-    /// 
+    ///
     fn deregister_universe(&mut self, universe: u16) -> Result<()> {
         is_universe_in_range(universe)?;
 
         match self.universes.binary_search(&universe) {
-            Err(_i) => { // Value not found
-                bail!(ErrorKind::UniverseNotFound("Attempted to de-register a universe that was never registered".to_string()))
+            Err(_i) => {
+                // Value not found
+                bail!(ErrorKind::UniverseNotFound(
+                    "Attempted to de-register a universe that was never registered".to_string()
+                ))
             }
-            Ok(i) => { // Value found, i is index.
+            Ok(i) => {
+                // Value found, i is index.
                 self.universes.remove(i);
                 Ok(())
             }
@@ -675,66 +707,81 @@ impl SacnSourceInternal {
     }
 
     /// Checks if the given universe is a valid universe to send on (within allowed range) and that it is registered with this SacnSourceInternal.
-    /// 
+    ///
     /// # Errors
     /// IllegalUniverse: Returned if the universe is outwith the allowed range, see (is_universe_in_range)[fn.is_universe_in_range.packet].
-    /// 
+    ///
     /// UniverseNotRegistered: Returned if the universe is not registered on the given SacnSourceInternal.
-    /// 
-    fn universe_allowed(&self, u: &u16) -> Result<()>{
+    ///
+    fn universe_allowed(&self, u: &u16) -> Result<()> {
         is_universe_in_range(*u)?;
 
         if !self.universes.contains(u) {
-            bail!(ErrorKind::UniverseNotRegistered(format!("Attempted to send on unregistered universe : {}", u).to_string()));
+            bail!(ErrorKind::UniverseNotRegistered(
+                format!("Attempted to send on unregistered universe : {}", u).to_string()
+            ));
         }
 
         Ok(())
     }
 
     /// Sends the given data to the given universes with the given priority, synchronisation address (universe) and destination ip.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// universe:     The sACN universes that the data should be set on, the data will be split over these universes with each UNIVERSE_CHANNEL_CAPACITY
     ///                 sized chunk sent to the next universe.
-    /// 
+    ///
     /// data:         The data that should be sent, must have a length greater than 0.
-    /// 
-    /// priority:     The E131 priority that the data should be sent with, must be less than E131_MAX_PRIORITY (const.E131_MAX_PRIORITY.packet), 
+    ///
+    /// priority:     The E131 priority that the data should be sent with, must be less than E131_MAX_PRIORITY (const.E131_MAX_PRIORITY.packet),
     ///                 if a value of None is provided then the default of E131_DEFAULT_PRIORITY (const.E131_DEFAULT_PRIORITY.packet) is used.
-    /// 
+    ///
     /// dst_ip:       The destination IP, can be Ipv4 or Ipv6, None if should be sent using ip multicast.
-    /// 
+    ///
     /// sync_address: The address to use for synchronisation, must be a valid universe, None indicates no synchronisation. If synchronisation is required a
     ///                 reasonable default address to use is the first universe that this data is being sent to.
-    /// 
-    /// As per ANSI E1.31-2018 Section 6.6.1 this method shouldn't be called at a higher refresher rate than specified in ANSI E1.11 [DMX] unless 
+    ///
+    /// As per ANSI E1.31-2018 Section 6.6.1 this method shouldn't be called at a higher refresher rate than specified in ANSI E1.11 [DMX] unless
     ///     configured by the user to do so in an environment which doesn't contain any E1.31 to DMX512-A converters.
-    /// 
+    ///
     /// Note as per ANSI-E1.31-2018 Appendix B.1 it is recommended to have a small delay before sending the follow up sync packet.
-    /// 
+    ///
     /// # Errors
     /// SenderAlreadyTerminated: Returned if this method is called on an SacnReceiverInternal that has already terminated.
-    /// 
+    ///
     /// InvalidInput: Returned if the data array has length 0 or if an insufficient number of universes for the given data are provided (each universe takes 513 bytes of data).
-    /// 
+    ///
     /// InvalidPriority: Returned if the priority is greater than the allowed maximum priority of E131_MAX_PRIORITY.
-    /// 
+    ///
     /// IllegalUniverse: Returned if the universe is outwith the allowed range as specified by ANSI E1.31-2018 Section 6.2.7.
-    /// 
+    ///
     /// UniverseNotRegistered: Returned if the universe is not registered on the given SacnSourceInternal.
-    /// 
+    ///
     /// ExceedUniverseCapacity: Returned if the data has a length greater than the maximum allowed within a universe (packet::UNIVERSE_CHANNEL_CAPACITY).
-    /// 
+    ///
     /// Io: Returned if the data fails to be sent on the socket, see send_to(fn.send_to.Socket).
-    /// 
-    fn send(&self, universes: &[u16], data: &[u8], priority: Option<u8>, dst_ip: Option<SocketAddr>, synchronisation_addr: Option<u16>) -> Result<()> {
-        if self.running == false { // Indicates that this sender has been terminated.
-            bail!(ErrorKind::SenderAlreadyTerminated("Attempted to send".to_string())); 
+    ///
+    fn send(
+        &self,
+        universes: &[u16],
+        data: &[u8],
+        priority: Option<u8>,
+        dst_ip: Option<SocketAddr>,
+        synchronisation_addr: Option<u16>,
+    ) -> Result<()> {
+        if self.running == false {
+            // Indicates that this sender has been terminated.
+            bail!(ErrorKind::SenderAlreadyTerminated(
+                "Attempted to send".to_string()
+            ));
         }
 
         if data.len() == 0 {
-           bail!(std::io::Error::new(std::io::ErrorKind::InvalidInput, "Must provide data to send, data.len() == 0"));
+            bail!(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Must provide data to send, data.len() == 0"
+            ));
         }
 
         // Check all the given universes are valid before doing any action.
@@ -745,58 +792,81 @@ impl SacnSourceInternal {
 
         // Check that the synchronisation universe is also valid.
         if synchronisation_addr.is_some() {
-            self.universe_allowed(&synchronisation_addr.unwrap()).chain_err(|| "Synchronisation universe not allowed")?;
+            self.universe_allowed(&synchronisation_addr.unwrap())
+                .chain_err(|| "Synchronisation universe not allowed")?;
         }
 
         // + 1 as there must be at least 1 universe required as the data isn't empty then additional universes for any more.
-        let required_universes = (data.len() as f64 / UNIVERSE_CHANNEL_CAPACITY as f64).ceil() as usize;
+        let required_universes =
+            (data.len() as f64 / UNIVERSE_CHANNEL_CAPACITY as f64).ceil() as usize;
 
         if universes.len() < required_universes {
-            bail!(std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("Must provide enough universes to send on, universes provided: {}", universes.len())));
+            bail!(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "Must provide enough universes to send on, universes provided: {}",
+                    universes.len()
+                )
+            ));
         }
-        
-        for i in 0 .. required_universes {
+
+        for i in 0..required_universes {
             let start_index = i * UNIVERSE_CHANNEL_CAPACITY;
             // Safety check to make sure that the end index doesn't exceed the data length
             let end_index = cmp::min((i + 1) * UNIVERSE_CHANNEL_CAPACITY, data.len());
 
-            self.send_universe(universes[i], &data[start_index .. end_index], 
-                priority.unwrap_or(E131_DEFAULT_PRIORITY), &dst_ip, synchronisation_addr.unwrap_or(NO_SYNC_UNIVERSE))?;
+            self.send_universe(
+                universes[i],
+                &data[start_index..end_index],
+                priority.unwrap_or(E131_DEFAULT_PRIORITY),
+                &dst_ip,
+                synchronisation_addr.unwrap_or(NO_SYNC_UNIVERSE),
+            )?;
         }
 
         Ok(())
     }
 
     /// Sends the given data to the given universe with the given priority, synchronisation address (universe) and destination ip.
-    /// 
+    ///
     /// # Arguments
     /// universe:     The sACN universe that the data should be set on.
-    /// 
+    ///
     /// data:         The data that should be sent, must be less than or equal in length to UNIVERSE_CHANNEL_CAPACITY(const.UNIVERSE_CHANNEL_CAPACITY.packet).
-    /// 
+    ///
     /// priority:     The E131 priority that the data should be sent with, must be less than E131_MAX_PRIORITY (const.E131_MAX_PRIORITY.packet), default E131_DEFAULT_PRIORITY.
-    /// 
+    ///
     /// dst_ip:       The destination IP, can be Ipv4 or Ipv6, None if should be sent using ip multicast.
-    /// 
+    ///
     /// sync_address: The address to use for synchronisation, must be a valid universe, 0 indicates no synchronisation.
-    /// 
+    ///
     /// # Errors
     /// InvalidInput: Returned if the priority is greater than the allowed maximum priority of E131_MAX_PRIORITY.
-    /// 
+    ///
     /// ExceedUniverseCapacity: Returned if the data has a length greater than the maximum allowed within a universe.
-    /// 
+    ///
     /// IllegalUniverse: Returned if the given universe is outwith the allowed range of universes,
     ///                     see (universe_to_ipv4_multicast_addr)[fn.universe_to_ipv4_multicast_addr.packet] and (universe_to_ipv6_multicast_addr)[fn.universe_to_ipv6_multicast_addr.packet].
-    /// 
+    ///
     /// Io: Returned if the data fails to be sent on the socket, see send_to(fn.send_to.Socket).
-    /// 
-    fn send_universe(&self, universe: u16, data: &[u8], priority: u8, dst_ip: &Option<SocketAddr>, sync_address: u16) -> Result<()> {
+    ///
+    fn send_universe(
+        &self,
+        universe: u16,
+        data: &[u8],
+        priority: u8,
+        dst_ip: &Option<SocketAddr>,
+        sync_address: u16,
+    ) -> Result<()> {
         if priority > E131_MAX_PRIORITY {
             bail!(ErrorKind::InvalidPriority(format!("Priority must be within allowed range of [0-E131_MAX_PRIORITY], priority provided: {}", priority)));
         }
 
         if data.len() > UNIVERSE_CHANNEL_CAPACITY {
-            bail!(ErrorKind::ExceedUniverseCapacity(format!("Data provided must fit in a single universe, data len: {}", data.len())));
+            bail!(ErrorKind::ExceedUniverseCapacity(format!(
+                "Data provided must fit in a single universe, data len: {}",
+                data.len()
+            )));
         }
 
         let mut sequence = match self.data_sequences.borrow().get(&universe) {
@@ -828,17 +898,23 @@ impl SacnSourceInternal {
         };
 
         if dst_ip.is_some() {
-            self.socket.send_to(&packet.pack_alloc().unwrap(), &dst_ip.unwrap().into()).chain_err(|| "Failed to send data unicast on socket")?;
+            self.socket
+                .send_to(&packet.pack_alloc().unwrap(), &dst_ip.unwrap().into())
+                .chain_err(|| "Failed to send data unicast on socket")?;
         } else {
             let dst;
 
-            if self.addr.is_ipv6(){
-                dst = universe_to_ipv6_multicast_addr(universe).chain_err(|| "Failed to convert universe to Ipv6 multicast address")?;
+            if self.addr.is_ipv6() {
+                dst = universe_to_ipv6_multicast_addr(universe)
+                    .chain_err(|| "Failed to convert universe to Ipv6 multicast address")?;
             } else {
-                dst = universe_to_ipv4_multicast_addr(universe).chain_err(|| "Failed to convert universe to Ipv4 multicast address")?;
+                dst = universe_to_ipv4_multicast_addr(universe)
+                    .chain_err(|| "Failed to convert universe to Ipv4 multicast address")?;
             }
 
-            self.socket.send_to(&packet.pack_alloc().unwrap(), &dst).chain_err(|| "Failed to send data multicast on socket")?;
+            self.socket
+                .send_to(&packet.pack_alloc().unwrap(), &dst)
+                .chain_err(|| "Failed to send data multicast on socket")?;
         }
 
         if sequence == 255 {
@@ -851,31 +927,31 @@ impl SacnSourceInternal {
     }
 
     /// Sends a synchronisation packet to trigger the sending of packets waiting to be sent together.
-    /// 
-    /// A common pattern would be to use the send method to send data to all the universes that should be synchronised using a 
-    /// chosen synchronisation universe then wait for a small time as per the recommendation in ANSI-E1.31-2018 Appendix B.1 and 
+    ///
+    /// A common pattern would be to use the send method to send data to all the universes that should be synchronised using a
+    /// chosen synchronisation universe then wait for a small time as per the recommendation in ANSI-E1.31-2018 Appendix B.1 and
     /// then send a synchronisation packet with the address of the synchronisation universe chosen to trigger the packets.
-    /// 
+    ///
     /// # Arguments
     /// universe: The universe of this synchronisation packet.
     /// dst_ip:   The destination IP address for this packet or None if it should be sent using multicast.
-    /// 
+    ///
     /// # Errors
     /// IllegalUniverse: Returned if the universe is outwith the allowed range of sACN universes as defined in ANSI E1.31-2018 Section 6.2.7.
-    /// 
+    ///
     /// UniverseNotRegistered: Returned if the universe is not registered on the given SacnSourceInternal.
-    /// 
+    ///
     /// Io: Returned if the packet fails to be sent using the underlying network socket.
-    /// 
+    ///
     /// SacnParsePackError: Returned if the sync packet fails to be packed.
-    /// 
+    ///
     fn send_sync_packet(&self, universe: u16, dst_ip: Option<SocketAddr>) -> Result<()> {
         self.universe_allowed(&universe)?;
 
         let ip;
 
         if dst_ip.is_none() {
-            if self.addr.is_ipv6(){
+            if self.addr.is_ipv6() {
                 ip = universe_to_ipv6_multicast_addr(universe)?;
             } else {
                 ip = universe_to_ipv4_multicast_addr(universe)?;
@@ -894,11 +970,13 @@ impl SacnSourceInternal {
                 cid: self.cid,
                 data: E131RootLayerData::SynchronizationPacket(SynchronizationPacketFramingLayer {
                     sequence_number: sequence,
-                    synchronization_address: universe
-                })
-            }
+                    synchronization_address: universe,
+                }),
+            },
         };
-        self.socket.send_to(&packet.pack_alloc()?, &ip).chain_err(|| "Failed to send sync packet on socket")?;
+        self.socket
+            .send_to(&packet.pack_alloc()?, &ip)
+            .chain_err(|| "Failed to send sync packet on socket")?;
 
         if sequence == 255 {
             sequence = 0;
@@ -910,28 +988,33 @@ impl SacnSourceInternal {
     }
 
     /// Sends a stream termination packet for the given universe.
-    /// 
-    /// In normal usage this method would be called three times to send three packets for termination as per 
+    ///
+    /// In normal usage this method would be called three times to send three packets for termination as per
     ///     ANSI E1.31-2018 Section 6.2.6, Stream_Terminated: Bit 6.
-    /// 
+    ///
     /// # Arguments
     /// universe: The universe of this synchronisation packet.
     /// dst_ip:   The destination IP address for this packet or None if it should be sent using multicast.
-    /// 
+    ///
     /// # Errors
     /// IllegalUniverse: Returned if the universe is outwith the allowed range of sACN universes as defined in ANSI E1.31-2018 Section 6.2.7.
-    /// 
+    ///
     /// UniverseNotRegistered: Returned if the universe is not registered on the given SacnSourceInternal.
-    /// 
+    ///
     /// Io: Returned if the termination packets fail to be sent on the underlying socket.
-    /// 
-    fn send_terminate_stream_pkt(&self, universe: u16, dst_ip: Option<SocketAddr>, start_code: u8) -> Result<()> {
+    ///
+    fn send_terminate_stream_pkt(
+        &self,
+        universe: u16,
+        dst_ip: Option<SocketAddr>,
+        start_code: u8,
+    ) -> Result<()> {
         self.universe_allowed(&universe)?;
 
-        let ip = match dst_ip{
+        let ip = match dst_ip {
             Some(x) => x.into(),
             None => {
-                if self.addr.is_ipv6(){
+                if self.addr.is_ipv6() {
                     universe_to_ipv6_multicast_addr(universe)?
                 } else {
                     universe_to_ipv4_multicast_addr(universe)?
@@ -977,23 +1060,23 @@ impl SacnSourceInternal {
     }
 
     /// Terminates a universe stream.
-    /// 
+    ///
     /// Terminates a stream to the specified universe by sending packets with the Stream_Terminated flag set to 1.
     /// Number of packets sent as per section 6.2.6 , Stream_Terminated: Bit 6 of ANSI E1.31-2018.
-    /// 
+    ///
     /// Arguments:
     /// universe: The universe that is being terminated.
     /// start_code: used for the first byte of the otherwise empty data payload to indicate the start_code of the data.
-    /// 
+    ///
     /// # Errors:
     /// IllegalUniverse: Returned if the universe is outwith the allowed range of sACN universes as defined in ANSI E1.31-2018 Section 6.2.7.
-    /// 
+    ///
     /// UniverseNotRegistered: Returned if the universe is not registered on this source.
-    /// 
+    ///
     /// Io: Returned if the termination packets fail to be sent on the socket.
-    /// 
+    ///
     fn terminate_stream(&mut self, universe: u16, start_code: u8) -> Result<()> {
-        for _ in 0 .. E131_TERMINATE_STREAM_PACKET_COUNT {
+        for _ in 0..E131_TERMINATE_STREAM_PACKET_COUNT {
             self.send_terminate_stream_pkt(universe, None, start_code)?;
         }
 
@@ -1002,16 +1085,16 @@ impl SacnSourceInternal {
     }
 
     /// Terminates the DMX source.
-    /// 
+    ///
     /// This includes terminating each registered universe with the start_code given.
-    /// 
+    ///
     /// Arguments:
     /// start_code: used for the first byte of the otherwise empty data payload to indicate the start_code of the data.
-    /// 
+    ///
     /// # Errors:
     /// Io: Returned if the termination packets fail to be sent on the underlying socket.
-    /// 
-    fn terminate(&mut self, start_code: u8) -> Result<()>{
+    ///
+    fn terminate(&mut self, start_code: u8) -> Result<()> {
         self.running = false;
         let universes = self.universes.clone(); // About to start manipulating self.universes as universes are removed so clone original list.
         for u in universes {
@@ -1021,43 +1104,55 @@ impl SacnSourceInternal {
     }
 
     /// Sends a universe discovery packet advertising the universes that this source is registered to send.
-    /// 
+    ///
     /// This packet may be broken down into multiple pages internally resulting in multiple UDP packets.
-    /// 
+    ///
     /// # Errors
     /// See (send_universe_discovery_detailed)[fn.send_universe_discovery_detailed.source].
-    /// 
-    fn send_universe_discovery(&self) -> Result<()>{
-        // Given a u16 universe field and self.universes containing no duplicates it means that the maximum total number of universes (65536, ignoring sACN restrictions) 
+    ///
+    fn send_universe_discovery(&self) -> Result<()> {
+        // Given a u16 universe field and self.universes containing no duplicates it means that the maximum total number of universes (65536, ignoring sACN restrictions)
         // divided by the number of universes per page (512) is 128 which therefore fits into the discovery universe 8 bit page field making this cast safe.
         let pages_req: u8 = ((self.universes.len() / DISCOVERY_UNI_PER_PAGE) + 1) as u8;
 
-        for p in 0 .. pages_req {
+        for p in 0..pages_req {
             let start_index = (p as usize) * DISCOVERY_UNI_PER_PAGE;
-            let end_index = min( ((p as usize) + 1) * DISCOVERY_UNI_PER_PAGE , self.universes.len());
-            self.send_universe_discovery_detailed(p, pages_req - 1, &self.universes[start_index .. end_index])?;
+            let end_index = min(
+                ((p as usize) + 1) * DISCOVERY_UNI_PER_PAGE,
+                self.universes.len(),
+            );
+            self.send_universe_discovery_detailed(
+                p,
+                pages_req - 1,
+                &self.universes[start_index..end_index],
+            )?;
         }
         Ok(())
     }
 
     /// Sends a page of a universe discovery packet.
-    /// 
+    ///
     /// There may be 1 or more pages for each full universe discovery packet with each page sent separately.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// page: The page number of this universe discovery page.
-    /// 
+    ///
     /// last_page: The last page that is expected as part of this universe discovery packet.
-    /// 
+    ///
     /// universes: The universes to include on the page.
-    /// 
+    ///
     /// # Errors
     /// Io: Returned if the discovery packet fails to be sent on the socket.
-    /// 
+    ///
     /// SacnParsePackError: Returned if the discovery packet cannot be packed to send.
-    /// 
-    fn send_universe_discovery_detailed(&self, page: u8, last_page: u8, universes: &[u16]) -> Result<()>{
+    ///
+    fn send_universe_discovery_detailed(
+        &self,
+        page: u8,
+        last_page: u8,
+        universes: &[u16],
+    ) -> Result<()> {
         let packet = AcnRootLayerProtocol {
             pdu: E131RootLayer {
                 cid: self.cid,
@@ -1075,7 +1170,7 @@ impl SacnSourceInternal {
         };
 
         let ip;
-        if self.addr.is_ipv6(){
+        if self.addr.is_ipv6() {
             ip = universe_to_ipv6_multicast_addr(E131_DISCOVERY_UNIVERSE)?;
         } else {
             ip = universe_to_ipv4_multicast_addr(E131_DISCOVERY_UNIVERSE)?;
@@ -1092,10 +1187,10 @@ impl SacnSourceInternal {
     }
 
     /// Sets the ACN CID device identifier.
-    /// 
+    ///
     /// # Arguments
     /// cid: The new CID identifier for this source. It is left to the user to ensure that this is always unique within the network the source is in.
-    /// 
+    ///
     fn set_cid(&mut self, cid: Uuid) {
         self.cid = cid;
     }
@@ -1106,16 +1201,18 @@ impl SacnSourceInternal {
     }
 
     /// Sets ACN source name.
-    /// 
+    ///
     /// # Argument
     /// name: The new name for the source, it is left to the user to ensure this is unique within the sACN network.
-    /// 
+    ///
     /// # Errors
     /// MalformedSourceName: Returned to indicate that the given source name is longer than the maximum allowed as per E131_SOURCE_NAME_FIELD_LENGTH.
-    /// 
+    ///
     fn set_name(&mut self, name: &str) -> Result<()> {
         if name.len() > E131_SOURCE_NAME_FIELD_LENGTH {
-            bail!(ErrorKind::MalformedSourceName("Source name provided is longer than maximum allowed".to_string()));
+            bail!(ErrorKind::MalformedSourceName(
+                "Source name provided is longer than maximum allowed".to_string()
+            ));
         }
         self.name = name.to_string();
 
@@ -1132,58 +1229,58 @@ impl SacnSourceInternal {
     /// # Arguments
     /// preview_mode: If true then all data packets from this SacnSourceInternal will have the Preview_Data flag set to true indicating that the data is not
     ///     for live output. If false then the flag will be set to false.
-    /// 
+    ///
     fn set_preview_mode(&mut self, preview_mode: bool) {
         self.preview_data = preview_mode;
     }
 
     /// Sets the multicast time to live.
-    /// 
+    ///
     /// # Arguments
     /// multicast_ttl: The new time to live value for network packets sent using multicast.
-    /// 
+    ///
     /// # Errors
     /// Io: Returned if the multicast TTL fails to be set on the underlying socket.
-    /// 
+    ///
     fn set_multicast_ttl(&self, multicast_ttl: u32) -> Result<()> {
         Ok(self.socket.set_multicast_ttl_v4(multicast_ttl)?)
     }
 
     /// Returns the current Time To Live for unicast packets send by this source.
-    /// 
+    ///
     /// # Errors
     /// Io: Returned if the TTL cannot be retrieved from the underlying socket.
-    /// 
+    ///
     fn ttl(&self) -> Result<u32> {
         Ok(self.socket.ttl()?)
     }
 
     /// Sets the Time To Live for unicast packets sent by this source.
-    /// 
+    ///
     /// # Arguments
     /// ttl: The new time to live value for network packets sent by the source.
-    /// 
+    ///
     /// # Errors
     /// Io: Returned if the TTL fails to be set on the underlying socket.
-    /// 
+    ///
     fn set_ttl(&mut self, ttl: u32) -> Result<()> {
         Ok(self.socket.set_ttl(ttl)?)
     }
 
     /// Returns the multicast time to live of the socket.
-    /// 
+    ///
     fn multicast_ttl(&self) -> Result<u32> {
         Ok(self.socket.multicast_ttl_v4()?)
     }
 
     /// Sets if multicast loop is enabled.
-    /// 
+    ///
     /// # Arguments:
     /// multicast_loop: If true then multicast loop is enabled, if false it is not.
-    /// 
+    ///
     /// # Errors
     /// Io: Returned if the set_multicast_loop option fails to be set on the socket.
-    /// 
+    ///
     fn set_multicast_loop_v4(&self, multicast_loop: bool) -> Result<()> {
         Ok(self.socket.set_multicast_loop_v4(multicast_loop)?)
     }
@@ -1200,76 +1297,79 @@ impl SacnSourceInternal {
 }
 
 /// Returns the locked internal SacnSourceInternal used within the SacnSource.
-/// 
+///
 /// This centralises the locking of the source to a single point within the code allowing any changes to the mechanism to be made in one place.
-/// 
+///
 /// This differs to (unlock_internal_mut) as it takes an immutable reference to internal.
-/// 
+///
 /// # Arguments
 /// internal: The SacnSourceInternal to unlock encapsulated within an Arc and Mutex.
-/// 
+///
 /// # Errors
 /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-/// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-/// 
-fn unlock_internal(internal: &Arc<Mutex<SacnSourceInternal>>) -> Result<MutexGuard<SacnSourceInternal>> {
+/// a panic while accessing causing the source to be left in a potentially inconsistent state.
+///
+fn unlock_internal(
+    internal: &Arc<Mutex<SacnSourceInternal>>,
+) -> Result<MutexGuard<SacnSourceInternal>> {
     match internal.lock() {
         Err(_) => {
-            // The PoisonError returned doesn't contain further information and just allows access to the internal potentially inconsistent sender which 
+            // The PoisonError returned doesn't contain further information and just allows access to the internal potentially inconsistent sender which
             // shouldn't be exposed to the user (as its internal and would have no use).
             // Cannot directly return the PoisonError due to PoisonError using a different error system to other std modules which doesn't work with
             // error_chain.
             bail!(ErrorKind::SourceCorrupt("Mutex poisoned".to_string()));
         }
-        Ok(lock) => {
-            Ok(lock)
-        }
+        Ok(lock) => Ok(lock),
     }
 }
 
 /// Returns the locked internal SacnSourceInternal used within the SacnSource.
-/// 
+///
 /// This centralises the locking of the source to a single point within the code allowing any changes to the mechanism to be made in one place.
-/// 
+///
 /// This differs to (unlock_internal) as it takes an mutable reference to internal.
-/// 
+///
 /// # Arguments
 /// internal: The SacnSourceInternal to unlock encapsulated within an Arc and Mutex.
-/// 
+///
 /// # Errors
 /// Returns an SourceCorrupt error if the Mutex used to control access to the internal sender is poisoned by a thread encountering
-/// a panic while accessing causing the source to be left in a potentially inconsistent state. 
-/// 
-fn unlock_internal_mut(internal: &mut Arc<Mutex<SacnSourceInternal>>) -> Result<MutexGuard<SacnSourceInternal>> {
+/// a panic while accessing causing the source to be left in a potentially inconsistent state.
+///
+fn unlock_internal_mut(
+    internal: &mut Arc<Mutex<SacnSourceInternal>>,
+) -> Result<MutexGuard<SacnSourceInternal>> {
     match internal.lock() {
         Err(_) => {
-            // The PoisonError returned doesn't contain further information and just allows access to the internal potentially inconsistent sender which 
+            // The PoisonError returned doesn't contain further information and just allows access to the internal potentially inconsistent sender which
             // shouldn't be exposed to the user (as its internal and would have no use).
             // Cannot directly return the PoisonError due to PoisonError using a different error system to other std modules which doesn't work with
             // error_chain.
             bail!(ErrorKind::SourceCorrupt("Mutex poisoned".to_string()));
         }
-        Ok(lock) => {
-            Ok(lock)
-        }
+        Ok(lock) => Ok(lock),
     }
 }
 
 /// Called periodically by the source update thread.
-/// 
+///
 /// Is responsible for sending the periodic universe discovery packets.
-/// 
+///
 /// # Arguments:
 /// src: A reference to the SacnSourceInternal for which to send the universe discovery packet with/from.
-/// 
+///
 /// # Errors
 /// Returns a SourceCorrupt error if the internal source mutex has been corrupted, see (unlock_internal)[unlock_internal].
-/// 
+///
 /// Returns an error if a discovery packet cannot be sent, see (send_universe_discovery)[fn.send_universe_discovery.source].
-/// 
-fn perform_periodic_update(src: &mut Arc<Mutex<SacnSourceInternal>>) -> Result<()>{
+///
+fn perform_periodic_update(src: &mut Arc<Mutex<SacnSourceInternal>>) -> Result<()> {
     let mut unwrap_src = unlock_internal_mut(src)?;
-    if unwrap_src.is_sending_discovery && Instant::now().duration_since(unwrap_src.last_discovery_advert_timestamp) > E131_UNIVERSE_DISCOVERY_INTERVAL {
+    if unwrap_src.is_sending_discovery
+        && Instant::now().duration_since(unwrap_src.last_discovery_advert_timestamp)
+            > E131_UNIVERSE_DISCOVERY_INTERVAL
+    {
         unwrap_src.send_universe_discovery()?;
         unwrap_src.last_discovery_advert_timestamp = Instant::now();
     }

--- a/tests/data_parse_tests.rs
+++ b/tests/data_parse_tests.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(rustfmt, rustfmt_skip)]
+
 // Copyright 2020 sacn Developers
 //
 // Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or

--- a/tests/data_parse_tests.rs
+++ b/tests/data_parse_tests.rs
@@ -33,11 +33,11 @@ const TEST_DATA_PACKET: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -63,7 +63,7 @@ const TEST_DATA_PACKET: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -71,7 +71,7 @@ const TEST_DATA_PACKET: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -100,11 +100,11 @@ const TEST_DATA_PACKET_PARTIAL: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x8B, 
+    0x70, 0x8B,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x70, 0x75,
@@ -130,7 +130,7 @@ const TEST_DATA_PACKET_PARTIAL: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -138,7 +138,7 @@ const TEST_DATA_PACKET_PARTIAL: &[u8] = &[
     /* Property value count = 30 */
     0x00, 0x1E,
     /* Property values */
-    0, 0, 0, 0, 0,   
+    0, 0, 0, 0, 0,
     0, 0, 0, 0, 0,
     0, 0, 0, 0, 0,
     0, 0, 0, 0, 0,
@@ -156,11 +156,11 @@ const TEST_DATA_PACKET_EMPTY: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x70, 0x58,
@@ -186,7 +186,7 @@ const TEST_DATA_PACKET_EMPTY: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -207,11 +207,11 @@ const TEST_DATA_PACKET_ROOT_LAYER_WRONG_PREAMBLE_SIZE_LOWER_BYTE: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -237,7 +237,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_WRONG_PREAMBLE_SIZE_LOWER_BYTE: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -245,7 +245,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_WRONG_PREAMBLE_SIZE_LOWER_BYTE: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -274,11 +274,11 @@ const TEST_DATA_PACKET_ROOT_LAYER_WRONG_PREAMBLE_SIZE_UPPER_BYTE: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -304,7 +304,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_WRONG_PREAMBLE_SIZE_UPPER_BYTE: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -312,7 +312,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_WRONG_PREAMBLE_SIZE_UPPER_BYTE: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -341,11 +341,11 @@ const TEST_DATA_PACKET_ROOT_LAYER_WRONG_POSTAMBLE_SIZE_UPPER_BYTE: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -371,7 +371,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_WRONG_POSTAMBLE_SIZE_UPPER_BYTE: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -379,7 +379,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_WRONG_POSTAMBLE_SIZE_UPPER_BYTE: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -408,11 +408,11 @@ const TEST_DATA_PACKET_ROOT_LAYER_WRONG_POSTAMBLE_SIZE_LOWER_BYTE: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -438,7 +438,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_WRONG_POSTAMBLE_SIZE_LOWER_BYTE: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -446,7 +446,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_WRONG_POSTAMBLE_SIZE_LOWER_BYTE: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -475,11 +475,11 @@ const TEST_DATA_PACKET_ROOT_LAYER_WRONG_ACN_IDENTIFIER: &[u8] = &[
     /* ACN Packet Identifier */
     0x42, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -505,7 +505,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_WRONG_ACN_IDENTIFIER: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -513,7 +513,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_WRONG_ACN_IDENTIFIER: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -542,11 +542,11 @@ const TEST_DATA_PACKET_ROOT_LAYER_WRONG_FLAGS: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x62, 0x6e, 
+    0x62, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -572,7 +572,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_WRONG_FLAGS: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -580,7 +580,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_WRONG_FLAGS: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -609,11 +609,11 @@ const TEST_DATA_PACKET_ROOT_LAYER_TOO_LOW_LENGTH: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6d, 
+    0x72, 0x6d,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -639,7 +639,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_TOO_LOW_LENGTH: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -647,7 +647,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_TOO_LOW_LENGTH: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -676,11 +676,11 @@ const TEST_DATA_PACKET_ROOT_LAYER_TOO_HIGH_LENGTH: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6f, 
+    0x72, 0x6f,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -706,7 +706,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_TOO_HIGH_LENGTH: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -714,7 +714,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_TOO_HIGH_LENGTH: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -743,11 +743,11 @@ const TEST_DATA_PACKET_ROOT_LAYER_UNKNOWN_ACN_VECTOR: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x14,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -773,7 +773,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_UNKNOWN_ACN_VECTOR: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -781,7 +781,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_UNKNOWN_ACN_VECTOR: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -810,11 +810,11 @@ const TEST_DATA_PACKET_ROOT_LAYER_EXTENDED_VECTOR: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x08,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -840,7 +840,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_EXTENDED_VECTOR: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -848,7 +848,7 @@ const TEST_DATA_PACKET_ROOT_LAYER_EXTENDED_VECTOR: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -877,7 +877,7 @@ const TEST_DATA_PACKET_TOO_LONG_CID: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
@@ -907,7 +907,7 @@ const TEST_DATA_PACKET_TOO_LONG_CID: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -915,7 +915,7 @@ const TEST_DATA_PACKET_TOO_LONG_CID: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -944,7 +944,7 @@ const TEST_DATA_PACKET_TOO_SHORT_CID: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
@@ -974,7 +974,7 @@ const TEST_DATA_PACKET_TOO_SHORT_CID: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -982,7 +982,7 @@ const TEST_DATA_PACKET_TOO_SHORT_CID: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1011,11 +1011,11 @@ const TEST_DATA_PACKET_FRAMING_LAYER_WRONG_FLAGS: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x82, 0x58,
@@ -1041,7 +1041,7 @@ const TEST_DATA_PACKET_FRAMING_LAYER_WRONG_FLAGS: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -1049,7 +1049,7 @@ const TEST_DATA_PACKET_FRAMING_LAYER_WRONG_FLAGS: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1078,11 +1078,11 @@ const TEST_DATA_PACKET_FRAMING_LAYER_LOW_LENGTH: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x50,
@@ -1108,7 +1108,7 @@ const TEST_DATA_PACKET_FRAMING_LAYER_LOW_LENGTH: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -1116,7 +1116,7 @@ const TEST_DATA_PACKET_FRAMING_LAYER_LOW_LENGTH: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1145,11 +1145,11 @@ const TEST_DATA_PACKET_FRAMING_LAYER_HIGH_LENGTH: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x62,
@@ -1175,7 +1175,7 @@ const TEST_DATA_PACKET_FRAMING_LAYER_HIGH_LENGTH: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -1183,7 +1183,7 @@ const TEST_DATA_PACKET_FRAMING_LAYER_HIGH_LENGTH: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1212,11 +1212,11 @@ const TEST_DATA_PACKET_FRAMING_LAYER_WRONG_VECTOR: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -1242,7 +1242,7 @@ const TEST_DATA_PACKET_FRAMING_LAYER_WRONG_VECTOR: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -1250,7 +1250,7 @@ const TEST_DATA_PACKET_FRAMING_LAYER_WRONG_VECTOR: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1279,11 +1279,11 @@ const TEST_DATA_PACKET_MAX_SOURCE_NAME: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -1319,7 +1319,7 @@ const TEST_DATA_PACKET_MAX_SOURCE_NAME: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -1327,7 +1327,7 @@ const TEST_DATA_PACKET_MAX_SOURCE_NAME: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1356,11 +1356,11 @@ const TEST_DATA_PACKET_NOT_NULL_TERMINATED_SOURCE_NAME: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -1396,7 +1396,7 @@ const TEST_DATA_PACKET_NOT_NULL_TERMINATED_SOURCE_NAME: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -1404,7 +1404,7 @@ const TEST_DATA_PACKET_NOT_NULL_TERMINATED_SOURCE_NAME: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1433,11 +1433,11 @@ const TEST_DATA_PACKET_TOO_HIGH_PRIORITY: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -1463,7 +1463,7 @@ const TEST_DATA_PACKET_TOO_HIGH_PRIORITY: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -1471,7 +1471,7 @@ const TEST_DATA_PACKET_TOO_HIGH_PRIORITY: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1500,11 +1500,11 @@ const TEST_DATA_PACKET_LOWEST_PRIORITY: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -1530,7 +1530,7 @@ const TEST_DATA_PACKET_LOWEST_PRIORITY: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -1538,7 +1538,7 @@ const TEST_DATA_PACKET_LOWEST_PRIORITY: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1568,11 +1568,11 @@ const TEST_DATA_PACKET_NO_SYNC_PACKET: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -1598,7 +1598,7 @@ const TEST_DATA_PACKET_NO_SYNC_PACKET: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -1606,7 +1606,7 @@ const TEST_DATA_PACKET_NO_SYNC_PACKET: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1635,11 +1635,11 @@ const TEST_DATA_PACKET_TOO_HIGH_SYNC_ADDR_PACKET: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -1665,7 +1665,7 @@ const TEST_DATA_PACKET_TOO_HIGH_SYNC_ADDR_PACKET: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -1673,7 +1673,7 @@ const TEST_DATA_PACKET_TOO_HIGH_SYNC_ADDR_PACKET: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1703,11 +1703,11 @@ const TEST_DATA_PACKET_OPTIONS_BIT_0_SET_PACKET: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -1733,7 +1733,7 @@ const TEST_DATA_PACKET_OPTIONS_BIT_0_SET_PACKET: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -1741,7 +1741,7 @@ const TEST_DATA_PACKET_OPTIONS_BIT_0_SET_PACKET: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1771,11 +1771,11 @@ const TEST_DATA_PACKET_OPTIONS_BIT_1_SET_PACKET: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -1801,7 +1801,7 @@ const TEST_DATA_PACKET_OPTIONS_BIT_1_SET_PACKET: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -1809,7 +1809,7 @@ const TEST_DATA_PACKET_OPTIONS_BIT_1_SET_PACKET: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1839,11 +1839,11 @@ const TEST_DATA_PACKET_OPTIONS_BIT_2_SET_PACKET: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -1869,7 +1869,7 @@ const TEST_DATA_PACKET_OPTIONS_BIT_2_SET_PACKET: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -1877,7 +1877,7 @@ const TEST_DATA_PACKET_OPTIONS_BIT_2_SET_PACKET: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1907,11 +1907,11 @@ const TEST_DATA_PACKET_OPTIONS_BIT_3_SET_PACKET: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -1937,7 +1937,7 @@ const TEST_DATA_PACKET_OPTIONS_BIT_3_SET_PACKET: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -1945,7 +1945,7 @@ const TEST_DATA_PACKET_OPTIONS_BIT_3_SET_PACKET: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1975,11 +1975,11 @@ const TEST_DATA_PACKET_OPTIONS_BIT_4_SET_PACKET: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -2005,7 +2005,7 @@ const TEST_DATA_PACKET_OPTIONS_BIT_4_SET_PACKET: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -2013,7 +2013,7 @@ const TEST_DATA_PACKET_OPTIONS_BIT_4_SET_PACKET: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2043,11 +2043,11 @@ const TEST_DATA_PACKET_OPTIONS_BIT_5_SET_PACKET: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -2073,7 +2073,7 @@ const TEST_DATA_PACKET_OPTIONS_BIT_5_SET_PACKET: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -2081,7 +2081,7 @@ const TEST_DATA_PACKET_OPTIONS_BIT_5_SET_PACKET: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2111,11 +2111,11 @@ const TEST_DATA_PACKET_OPTIONS_BIT_6_SET_PACKET: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -2141,7 +2141,7 @@ const TEST_DATA_PACKET_OPTIONS_BIT_6_SET_PACKET: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -2149,7 +2149,7 @@ const TEST_DATA_PACKET_OPTIONS_BIT_6_SET_PACKET: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2179,11 +2179,11 @@ const TEST_DATA_PACKET_OPTIONS_BIT_7_SET_PACKET: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -2209,7 +2209,7 @@ const TEST_DATA_PACKET_OPTIONS_BIT_7_SET_PACKET: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -2217,7 +2217,7 @@ const TEST_DATA_PACKET_OPTIONS_BIT_7_SET_PACKET: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2247,11 +2247,11 @@ const TEST_DATA_PACKET_TOO_HIGH_UNIVERSE: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -2277,7 +2277,7 @@ const TEST_DATA_PACKET_TOO_HIGH_UNIVERSE: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -2285,7 +2285,7 @@ const TEST_DATA_PACKET_TOO_HIGH_UNIVERSE: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2315,11 +2315,11 @@ const TEST_DATA_PACKET_TOO_LOW_UNIVERSE: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -2345,7 +2345,7 @@ const TEST_DATA_PACKET_TOO_LOW_UNIVERSE: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -2353,7 +2353,7 @@ const TEST_DATA_PACKET_TOO_LOW_UNIVERSE: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2383,11 +2383,11 @@ const TEST_DATA_PACKET_DMP_LAYER_TOO_HIGH_LENGTH: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -2413,7 +2413,7 @@ const TEST_DATA_PACKET_DMP_LAYER_TOO_HIGH_LENGTH: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -2421,7 +2421,7 @@ const TEST_DATA_PACKET_DMP_LAYER_TOO_HIGH_LENGTH: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2451,11 +2451,11 @@ const TEST_DATA_PACKET_DMP_LAYER_TOO_LOW_LENGTH: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -2481,7 +2481,7 @@ const TEST_DATA_PACKET_DMP_LAYER_TOO_LOW_LENGTH: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -2489,7 +2489,7 @@ const TEST_DATA_PACKET_DMP_LAYER_TOO_LOW_LENGTH: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2519,11 +2519,11 @@ const TEST_DATA_PACKET_DMP_LAYER_WRONG_FLAGS: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -2549,7 +2549,7 @@ const TEST_DATA_PACKET_DMP_LAYER_WRONG_FLAGS: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -2557,7 +2557,7 @@ const TEST_DATA_PACKET_DMP_LAYER_WRONG_FLAGS: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2587,11 +2587,11 @@ const TEST_DATA_PACKET_DMP_LAYER_WRONG_VECTOR: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -2617,7 +2617,7 @@ const TEST_DATA_PACKET_DMP_LAYER_WRONG_VECTOR: &[u8] = &[
     /* Vector */
     0x07,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -2625,7 +2625,7 @@ const TEST_DATA_PACKET_DMP_LAYER_WRONG_VECTOR: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2655,11 +2655,11 @@ const TEST_DATA_PACKET_DMP_LAYER_WRONG_ADDRESS_DATA: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -2685,7 +2685,7 @@ const TEST_DATA_PACKET_DMP_LAYER_WRONG_ADDRESS_DATA: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa2, 
+    0xa2,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -2693,7 +2693,7 @@ const TEST_DATA_PACKET_DMP_LAYER_WRONG_ADDRESS_DATA: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2723,11 +2723,11 @@ const TEST_DATA_PACKET_DMP_LAYER_WRONG_FIRST_PROPERTY_ADDRESS: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -2753,7 +2753,7 @@ const TEST_DATA_PACKET_DMP_LAYER_WRONG_FIRST_PROPERTY_ADDRESS: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x01,
     /* Address Increment */
@@ -2761,7 +2761,7 @@ const TEST_DATA_PACKET_DMP_LAYER_WRONG_FIRST_PROPERTY_ADDRESS: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2791,11 +2791,11 @@ const TEST_DATA_PACKET_DMP_LAYER_WRONG_ADDRESS_INCREMENT: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -2821,7 +2821,7 @@ const TEST_DATA_PACKET_DMP_LAYER_WRONG_ADDRESS_INCREMENT: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -2829,7 +2829,7 @@ const TEST_DATA_PACKET_DMP_LAYER_WRONG_ADDRESS_INCREMENT: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2859,11 +2859,11 @@ const TEST_DATA_PACKET_DMP_LAYER_TOO_HIGH_PROPERTY_COUNT: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -2889,7 +2889,7 @@ const TEST_DATA_PACKET_DMP_LAYER_TOO_HIGH_PROPERTY_COUNT: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -2897,7 +2897,7 @@ const TEST_DATA_PACKET_DMP_LAYER_TOO_HIGH_PROPERTY_COUNT: &[u8] = &[
     /* Property value count */
     0x02, 0x02,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2927,11 +2927,11 @@ const TEST_DATA_PACKET_DMP_LAYER_TOO_LOW_PROPERTY_COUNT: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -2957,7 +2957,7 @@ const TEST_DATA_PACKET_DMP_LAYER_TOO_LOW_PROPERTY_COUNT: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -2965,7 +2965,7 @@ const TEST_DATA_PACKET_DMP_LAYER_TOO_LOW_PROPERTY_COUNT: &[u8] = &[
     /* Property value count */
     0x02, 0x00,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2996,11 +2996,11 @@ const TEST_TERMINATION_FULL_PROPERTY_VALUES_PACKET: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x72, 0x6e, 
+    0x72, 0x6e,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length */
     0x72, 0x58,
@@ -3026,7 +3026,7 @@ const TEST_TERMINATION_FULL_PROPERTY_VALUES_PACKET: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -3034,7 +3034,7 @@ const TEST_TERMINATION_FULL_PROPERTY_VALUES_PACKET: &[u8] = &[
     /* Property value count */
     0x02, 0x01,
     /* Property values */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3065,11 +3065,11 @@ const TEST_TERMINATION_EMPTY_PROPERTY_VALUES_PACKET: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol, Length = 109*/
-    0x70, 0x6D, 
+    0x70, 0x6D,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length, Length = 87 */
     0x70, 0x57,
@@ -3095,7 +3095,7 @@ const TEST_TERMINATION_EMPTY_PROPERTY_VALUES_PACKET: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -3116,11 +3116,11 @@ const TEST_TERMINATION_PARTIAL_PROPERTY_VALUES_PACKET: &[u8] = &[
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol, Length = 139 */
-    0x70, 0x8B, 
+    0x70, 0x8B,
     /* Vector */
     0x00, 0x00, 0x00, 0x04,
     /* CID */
-    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 
+    0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Data Packet Framing Layer */
     /* Flags and Length, Length = 117 */
     0x70, 0x75,
@@ -3146,7 +3146,7 @@ const TEST_TERMINATION_PARTIAL_PROPERTY_VALUES_PACKET: &[u8] = &[
     /* Vector */
     0x02,
     /* Address and Data Type */
-    0xa1, 
+    0xa1,
     /* First Property Address */
     0x00, 0x00,
     /* Address Increment */
@@ -3154,7 +3154,7 @@ const TEST_TERMINATION_PARTIAL_PROPERTY_VALUES_PACKET: &[u8] = &[
     /* Property value count = 30 */
     0x00, 0x1E,
     /* Property values */
-    0, 0, 0, 0, 0,   
+    0, 0, 0, 0, 0,
     0, 0, 0, 0, 0,
     0, 0, 0, 0, 0,
     0, 0, 0, 0, 0,
@@ -3276,7 +3276,7 @@ fn test_malformed_data_packet_wrong_preample_lower_byte_parse() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3299,7 +3299,7 @@ fn test_malformed_data_packet_wrong_preample_upper_byte_parse() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3322,7 +3322,7 @@ fn test_malformed_data_packet_wrong_postample_lower_byte_parse() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3345,7 +3345,7 @@ fn test_malformed_data_packet_wrong_postample_upper_byte_parse() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3368,7 +3368,7 @@ fn test_malformed_data_packet_root_layer_wrong_flags() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3391,7 +3391,7 @@ fn test_malformed_data_packet_root_layer_too_low_length() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3414,7 +3414,7 @@ fn test_malformed_data_packet_root_layer_too_high_length() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3437,7 +3437,7 @@ fn test_malformed_data_packet_wrong_acn_identifier_parse() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3460,7 +3460,7 @@ fn test_malformed_data_packet_unknown_acn_vector_parse() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3485,7 +3485,7 @@ fn test_malformed_data_packet_extended_acn_vector_parse() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3510,7 +3510,7 @@ fn test_malformed_data_packet_too_long_cid_parse() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3533,7 +3533,7 @@ fn test_malformed_data_packet_too_short_cid_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3556,7 +3556,7 @@ fn test_malformed_data_packet_framing_layer_wrong_flags_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3579,7 +3579,7 @@ fn test_malformed_data_packet_framing_layer_low_length_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3602,7 +3602,7 @@ fn test_malformed_data_packet_framing_layer_high_length_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3625,7 +3625,7 @@ fn test_malformed_data_packet_framing_layer_wrong_vector_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3680,7 +3680,7 @@ fn test_malformed_data_packet_source_name_not_null_terminated_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3703,7 +3703,7 @@ fn test_malformed_data_packet_too_high_priority_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3731,9 +3731,9 @@ fn test_data_packet_lowest_priority_parse() {
                     assert!(!dpfl.stream_terminated);
                     assert!(!dpfl.force_synchronization);
                     assert_eq!(dpfl.universe, 1);
-                    assert_eq!(dpfl.data.property_values, 
+                    assert_eq!(dpfl.data.property_values,
                         vec!{
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3777,9 +3777,9 @@ fn test_data_packet_no_sync_parse() {
                     assert!(!dpfl.stream_terminated);
                     assert!(!dpfl.force_synchronization);
                     assert_eq!(dpfl.universe, 1);
-                    assert_eq!(dpfl.data.property_values, 
+                    assert_eq!(dpfl.data.property_values,
                         vec!{
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3818,7 +3818,7 @@ fn test_malformed_data_packet_too_high_sync_addr_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -3846,9 +3846,9 @@ fn test_data_packet_options_bit_0_set_parse() {
                     assert!(!dpfl.stream_terminated);
                     assert!(!dpfl.force_synchronization);
                     assert_eq!(dpfl.universe, 1);
-                    assert_eq!(dpfl.data.property_values, 
+                    assert_eq!(dpfl.data.property_values,
                         vec!{
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3894,9 +3894,9 @@ fn test_data_packet_options_bit_1_set_parse() {
                     assert!(!dpfl.stream_terminated);
                     assert!(!dpfl.force_synchronization);
                     assert_eq!(dpfl.universe, 1);
-                    assert_eq!(dpfl.data.property_values, 
+                    assert_eq!(dpfl.data.property_values,
                         vec!{
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3942,9 +3942,9 @@ fn test_data_packet_options_bit_2_set_parse() {
                     assert!(!dpfl.stream_terminated);
                     assert!(!dpfl.force_synchronization);
                     assert_eq!(dpfl.universe, 1);
-                    assert_eq!(dpfl.data.property_values, 
+                    assert_eq!(dpfl.data.property_values,
                         vec!{
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3990,9 +3990,9 @@ fn test_data_packet_options_bit_3_set_parse() {
                     assert!(!dpfl.stream_terminated);
                     assert!(!dpfl.force_synchronization);
                     assert_eq!(dpfl.universe, 1);
-                    assert_eq!(dpfl.data.property_values, 
+                    assert_eq!(dpfl.data.property_values,
                         vec!{
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -4038,9 +4038,9 @@ fn test_data_packet_options_bit_4_set_parse() {
                     assert!(!dpfl.stream_terminated);
                     assert!(!dpfl.force_synchronization);
                     assert_eq!(dpfl.universe, 1);
-                    assert_eq!(dpfl.data.property_values, 
+                    assert_eq!(dpfl.data.property_values,
                         vec!{
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -4084,9 +4084,9 @@ fn test_data_packet_options_bit_5_set_parse() {
                     assert!(!dpfl.stream_terminated);
                     assert!(dpfl.force_synchronization);
                     assert_eq!(dpfl.universe, 1);
-                    assert_eq!(dpfl.data.property_values, 
+                    assert_eq!(dpfl.data.property_values,
                         vec!{
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -4132,9 +4132,9 @@ fn test_data_packet_options_bit_6_set_parse() {
                     assert!(dpfl.stream_terminated);
                     assert!(!dpfl.force_synchronization);
                     assert_eq!(dpfl.universe, 1);
-                    assert_eq!(dpfl.data.property_values, 
+                    assert_eq!(dpfl.data.property_values,
                         vec!{
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -4180,9 +4180,9 @@ fn test_data_packet_options_bit_7_set_parse() {
                     assert!(!dpfl.stream_terminated);
                     assert!(!dpfl.force_synchronization);
                     assert_eq!(dpfl.universe, 1);
-                    assert_eq!(dpfl.data.property_values, 
+                    assert_eq!(dpfl.data.property_values,
                         vec!{
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -4221,7 +4221,7 @@ fn test_malformed_data_packet_too_high_universe_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -4244,7 +4244,7 @@ fn test_malformed_data_packet_too_low_universe_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -4267,7 +4267,7 @@ fn test_malformed_data_packet_dmp_layer_too_high_length_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -4290,7 +4290,7 @@ fn test_malformed_data_packet_dmp_layer_too_low_length_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -4313,7 +4313,7 @@ fn test_malformed_data_packet_dmp_layer_wrong_flags_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -4336,7 +4336,7 @@ fn test_malformed_data_packet_dmp_layer_wrong_vector_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -4359,7 +4359,7 @@ fn test_malformed_data_packet_dmp_layer_wrong_address_data_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -4382,7 +4382,7 @@ fn test_malformed_data_packet_dmp_layer_wrong_first_property_address_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -4405,7 +4405,7 @@ fn test_malformed_data_packet_dmp_layer_wrong_address_increment_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -4428,7 +4428,7 @@ fn test_malformed_data_packet_dmp_layer_too_high_property_count_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -4451,7 +4451,7 @@ fn test_malformed_data_packet_dmp_layer_too_low_property_count_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -4479,9 +4479,9 @@ fn test_termination_packet_full_property_values_parse() {
                     assert!(dpfl.stream_terminated);
                     assert!(!dpfl.force_synchronization);
                     assert_eq!(dpfl.universe, 1);
-                    assert_eq!(dpfl.data.property_values, 
+                    assert_eq!(dpfl.data.property_values,
                         vec!{
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -4525,9 +4525,9 @@ fn test_termination_packet_partial_property_values_parse() {
                     assert!(dpfl.stream_terminated);
                     assert!(!dpfl.force_synchronization);
                     assert_eq!(dpfl.universe, 1);
-                    assert_eq!(dpfl.data.property_values, 
+                    assert_eq!(dpfl.data.property_values,
                         vec!{
-                            0, 0, 0, 0, 0,   
+                            0, 0, 0, 0, 0,
                             0, 0, 0, 0, 0,
                             0, 0, 0, 0, 0,
                             0, 0, 0, 0, 0,

--- a/tests/discovery_parse_tests.rs
+++ b/tests/discovery_parse_tests.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(rustfmt, rustfmt_skip)]
+
 extern crate sacn;
 extern crate uuid;
 

--- a/tests/discovery_parse_tests.rs
+++ b/tests/discovery_parse_tests.rs
@@ -28,37 +28,37 @@ const UNIVERSE_DISCOVERY_PACKET_EXPECTED_MAX_SIZE: usize = 1144;
 const TEST_UNIVERSE_DISCOVERY_PACKET: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x70, 0x58, 
+    0x70, 0x58,
     /* Vector */
-    0x00, 0x00, 0x00, 0x02, 
+    0x00, 0x00, 0x00, 0x02,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x70, 0x0e, 
+    0x70, 0x0e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     1,
     /* Last Page */
-    2, 
+    2,
     /* Universes, note each universe takes 2 bytes so this represents 3 universes (0x0001, 0x0203, 0x0405) not 6. */
     0x0, 0x1, 0x2, 0x3, 0x4, 0x5,
 ];
@@ -67,37 +67,37 @@ const TEST_UNIVERSE_DISCOVERY_PACKET: &[u8] = &[
 const TEST_UNIVERSE_DISCOVERY_PACKET_ROOT_LAYER_UNKNOWN_VECTOR: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x01, 0x08, 
+    0x00, 0x00, 0x01, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x70, 0x58, 
+    0x70, 0x58,
     /* Vector */
-    0x00, 0x00, 0x00, 0x02, 
+    0x00, 0x00, 0x00, 0x02,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x70, 0x0e, 
+    0x70, 0x0e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     1,
     /* Last Page */
-    2, 
+    2,
     /* Universes */
     0, 1, 2, 3, 4, 5,
 ];
@@ -106,37 +106,37 @@ const TEST_UNIVERSE_DISCOVERY_PACKET_ROOT_LAYER_UNKNOWN_VECTOR: &[u8] = &[
 const TEST_UNIVERSE_DISCOVERY_PACKET_ROOT_LAYER_DATA_VECTOR: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x04, 
+    0x00, 0x00, 0x00, 0x04,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x70, 0x58, 
+    0x70, 0x58,
     /* Vector */
-    0x00, 0x00, 0x00, 0x02, 
+    0x00, 0x00, 0x00, 0x02,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x70, 0x0e, 
+    0x70, 0x0e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     1,
     /* Last Page */
-    2, 
+    2,
     /* Universes */
     0, 1, 2, 3, 4, 5,
 ];
@@ -145,37 +145,37 @@ const TEST_UNIVERSE_DISCOVERY_PACKET_ROOT_LAYER_DATA_VECTOR: &[u8] = &[
 const TEST_UNIVERSE_DISCOVERY_PACKET_WRONG_FLAGS: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x60, 0x6e, 
+    0x60, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x70, 0x58, 
+    0x70, 0x58,
     /* Vector */
-    0x00, 0x00, 0x00, 0x02, 
+    0x00, 0x00, 0x00, 0x02,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x70, 0x0e, 
+    0x70, 0x0e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     1,
     /* Last Page */
-    2, 
+    2,
     /* Universes */
     0, 1, 2, 3, 4, 5,
 ];
@@ -184,37 +184,37 @@ const TEST_UNIVERSE_DISCOVERY_PACKET_WRONG_FLAGS: &[u8] = &[
 const TEST_UNIVERSE_DISCOVERY_PACKET_TOO_LONG_CID: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x70, 0x58, 
+    0x70, 0x58,
     /* Vector */
-    0x00, 0x00, 0x00, 0x02, 
+    0x00, 0x00, 0x00, 0x02,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x70, 0x0e, 
+    0x70, 0x0e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     1,
     /* Last Page */
-    2, 
+    2,
     /* Universes */
     0, 1, 2, 3, 4, 5,
 ];
@@ -223,37 +223,37 @@ const TEST_UNIVERSE_DISCOVERY_PACKET_TOO_LONG_CID: &[u8] = &[
 const TEST_UNIVERSE_DISCOVERY_PACKET_TOO_SHORT_CID: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x70, 0x58, 
+    0x70, 0x58,
     /* Vector */
-    0x00, 0x00, 0x00, 0x02, 
+    0x00, 0x00, 0x00, 0x02,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x70, 0x0e, 
+    0x70, 0x0e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     1,
     /* Last Page */
-    2, 
+    2,
     /* Universes */
     0, 1, 2, 3, 4, 5,
 ];
@@ -262,37 +262,37 @@ const TEST_UNIVERSE_DISCOVERY_PACKET_TOO_SHORT_CID: &[u8] = &[
 const TEST_UNIVERSE_DISCOVERY_PACKET_FRAMING_LAYER_WRONG_FLAGS: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x60, 0x58, 
+    0x60, 0x58,
     /* Vector */
-    0x00, 0x00, 0x00, 0x02, 
+    0x00, 0x00, 0x00, 0x02,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x70, 0x0e, 
+    0x70, 0x0e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     1,
     /* Last Page */
-    2, 
+    2,
     /* Universes */
     0, 1, 2, 3, 4, 5,
 ];
@@ -301,37 +301,37 @@ const TEST_UNIVERSE_DISCOVERY_PACKET_FRAMING_LAYER_WRONG_FLAGS: &[u8] = &[
 const TEST_UNIVERSE_DISCOVERY_PACKET_FRAMING_LAYER_LENGTH_TOO_SHORT: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x70, 0x57, 
+    0x70, 0x57,
     /* Vector */
-    0x00, 0x00, 0x00, 0x02, 
+    0x00, 0x00, 0x00, 0x02,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x70, 0x0e, 
+    0x70, 0x0e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     1,
     /* Last Page */
-    2, 
+    2,
     /* Universes */
     0, 1, 2, 3, 4, 5,
 ];
@@ -340,37 +340,37 @@ const TEST_UNIVERSE_DISCOVERY_PACKET_FRAMING_LAYER_LENGTH_TOO_SHORT: &[u8] = &[
 const TEST_UNIVERSE_DISCOVERY_PACKET_FRAMING_LAYER_LENGTH_TOO_LONG: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x70, 0x59, 
+    0x70, 0x59,
     /* Vector */
-    0x00, 0x00, 0x00, 0x02, 
+    0x00, 0x00, 0x00, 0x02,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x70, 0x0e, 
+    0x70, 0x0e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     1,
     /* Last Page */
-    2, 
+    2,
     /* Universes */
     0, 1, 2, 3, 4, 5,
 ];
@@ -379,37 +379,37 @@ const TEST_UNIVERSE_DISCOVERY_PACKET_FRAMING_LAYER_LENGTH_TOO_LONG: &[u8] = &[
 const TEST_UNIVERSE_DISCOVERY_PACKET_SYNC_FRAMING_VECTOR: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x70, 0x58, 
+    0x70, 0x58,
     /* Vector, Set to the value for a synchronisation packet */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x70, 0x0e, 
+    0x70, 0x0e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     1,
     /* Last Page */
-    2, 
+    2,
     /* Universes */
     0, 1, 2, 3, 4, 5,
 ];
@@ -418,77 +418,77 @@ const TEST_UNIVERSE_DISCOVERY_PACKET_SYNC_FRAMING_VECTOR: &[u8] = &[
 const TEST_UNIVERSE_DISCOVERY_PACKET_UNKNOWN_FRAMING_VECTOR: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x70, 0x58, 
+    0x70, 0x58,
     /* Vector, Set to an unknown value*/
-    0x00, 0x00, 0x00, 0x07, 
+    0x00, 0x00, 0x00, 0x07,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x70, 0x0e, 
+    0x70, 0x0e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     1,
     /* Last Page */
-    2, 
+    2,
     /* Universes */
     0, 1, 2, 3, 4, 5,
 ];
 
-/// Universe discovery packet with the reserved bytes set to values, this should be ignored and the packet 
+/// Universe discovery packet with the reserved bytes set to values, this should be ignored and the packet
 /// parsed normally as per ANSI E1.31-2018 Section 6.4.3.
 const TEST_UNIVERSE_DISCOVERY_PACKET_ARBITRARY_RESERVED: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x70, 0x58, 
+    0x70, 0x58,
     /* Vector */
-    0x00, 0x00, 0x00, 0x02, 
+    0x00, 0x00, 0x00, 0x02,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved, Set to arbitrary values */
-    255, 254, 253, 252, 
+    255, 254, 253, 252,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x70, 0x0e, 
+    0x70, 0x0e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     1,
     /* Last Page */
-    2, 
+    2,
     /* Universes (3 universes, 0x0001, 0x0203, 0x0405) */
     0, 1, 2, 3, 4, 5,
 ];
@@ -498,37 +498,37 @@ const TEST_UNIVERSE_DISCOVERY_PACKET_ARBITRARY_RESERVED: &[u8] = &[
 const TEST_UNIVERSE_DISCOVERY_PACKET_DISCOVERY_LAYER_WRONG_FLAGS: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x70, 0x58, 
+    0x70, 0x58,
     /* Vector */
-    0x00, 0x00, 0x00, 0x02, 
+    0x00, 0x00, 0x00, 0x02,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x60, 0x0e, 
+    0x60, 0x0e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     1,
     /* Last Page */
-    2, 
+    2,
     /* Universes */
     0, 1, 2, 3, 4, 5,
 ];
@@ -538,37 +538,37 @@ const TEST_UNIVERSE_DISCOVERY_PACKET_DISCOVERY_LAYER_WRONG_FLAGS: &[u8] = &[
 const TEST_UNIVERSE_DISCOVERY_PACKET_DISCOVERY_LAYER_LENGTH_TOO_SHORT: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x70, 0x58, 
+    0x70, 0x58,
     /* Vector */
-    0x00, 0x00, 0x00, 0x02, 
+    0x00, 0x00, 0x00, 0x02,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x70, 0x0d, 
+    0x70, 0x0d,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     1,
     /* Last Page */
-    2, 
+    2,
     /* Universes */
     0, 1, 2, 3, 4, 5,
 ];
@@ -578,37 +578,37 @@ const TEST_UNIVERSE_DISCOVERY_PACKET_DISCOVERY_LAYER_LENGTH_TOO_SHORT: &[u8] = &
 const TEST_UNIVERSE_DISCOVERY_PACKET_DISCOVERY_LAYER_LENGTH_TOO_LONG: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x70, 0x58, 
+    0x70, 0x58,
     /* Vector */
-    0x00, 0x00, 0x00, 0x02, 
+    0x00, 0x00, 0x00, 0x02,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x70, 0x0f, 
+    0x70, 0x0f,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     1,
     /* Last Page */
-    2, 
+    2,
     /* Universes */
     0, 1, 2, 3, 4, 5,
 ];
@@ -618,37 +618,37 @@ const TEST_UNIVERSE_DISCOVERY_PACKET_DISCOVERY_LAYER_LENGTH_TOO_LONG: &[u8] = &[
 const TEST_UNIVERSE_DISCOVERY_PACKET_DISCOVERY_LAYER_VECTOR_UNKNOWN: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x70, 0x58, 
+    0x70, 0x58,
     /* Vector */
-    0x00, 0x00, 0x00, 0x02, 
+    0x00, 0x00, 0x00, 0x02,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x70, 0x0e, 
+    0x70, 0x0e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x00, 
+    0x00, 0x00, 0x00, 0x00,
     /* Page */
     1,
     /* Last Page */
-    2, 
+    2,
     /* Universes */
     0, 1, 2, 3, 4, 5,
 ];
@@ -658,37 +658,37 @@ const TEST_UNIVERSE_DISCOVERY_PACKET_DISCOVERY_LAYER_VECTOR_UNKNOWN: &[u8] = &[
 const TEST_UNIVERSE_DISCOVERY_PACKET_PAGE_HIGHER_THAN_LAST_PAGE: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x70, 0x58, 
+    0x70, 0x58,
     /* Vector */
-    0x00, 0x00, 0x00, 0x02, 
+    0x00, 0x00, 0x00, 0x02,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x70, 0x0e, 
+    0x70, 0x0e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     3,
     /* Last Page */
-    2, 
+    2,
     /* Universes */
     0, 1, 2, 3, 4, 5,
 ];
@@ -698,37 +698,37 @@ const TEST_UNIVERSE_DISCOVERY_PACKET_PAGE_HIGHER_THAN_LAST_PAGE: &[u8] = &[
 const TEST_UNIVERSE_DISCOVERY_PACKET_DECENDING_ORDER: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x70, 0x58, 
+    0x70, 0x58,
     /* Vector */
-    0x00, 0x00, 0x00, 0x02, 
+    0x00, 0x00, 0x00, 0x02,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x70, 0x0e, 
+    0x70, 0x0e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     1,
     /* Last Page */
-    2, 
+    2,
     /* Universes */
     5, 4, 3, 2, 1, 0,
 ];
@@ -738,37 +738,37 @@ const TEST_UNIVERSE_DISCOVERY_PACKET_DECENDING_ORDER: &[u8] = &[
 const TEST_UNIVERSE_DISCOVERY_PACKET_RANDOM_ORDER: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x6e, 
+    0x70, 0x6e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    0x70, 0x58, 
+    0x70, 0x58,
     /* Vector */
-    0x00, 0x00, 0x00, 0x02, 
+    0x00, 0x00, 0x00, 0x02,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
-    0x70, 0x0e, 
+    0x70, 0x0e,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     1,
     /* Last Page */
-    2, 
+    2,
     /* Universes */
     3, 7, 5, 9, 1, 2,
 ];
@@ -820,7 +820,7 @@ fn test_discovery_packet_root_layer_unknown_vector_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -845,7 +845,7 @@ fn test_discovery_packet_root_layer_data_vector_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -868,7 +868,7 @@ fn test_discovery_packet_too_short_cid_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -885,7 +885,7 @@ fn test_discovery_packet_too_long_cid_parse() {
         Err(e) => {
             match e.kind() {
                 ErrorKind::SacnParsePackError(_) => {
-                    // Difficult to predict / assert what error should be caused by a field being too long as all 
+                    // Difficult to predict / assert what error should be caused by a field being too long as all
                     // other fields will be shifted and no clear way to know the true end of the CID field.
                     // Therefore just assert that the packet was detected as malformed rather than a specific error.
                     assert!(true, "Expected error family returned");
@@ -894,7 +894,7 @@ fn test_discovery_packet_too_long_cid_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -917,7 +917,7 @@ fn test_discovery_packet_wrong_flags_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -940,7 +940,7 @@ fn test_discovery_packet_framing_layer_length_too_long_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -963,7 +963,7 @@ fn test_discovery_packet_framing_layer_length_too_short_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -986,7 +986,7 @@ fn test_discovery_packet_framing_layer_wrong_flags_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -1012,7 +1012,7 @@ fn test_discovery_packet_sync_framing_vector_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -1035,7 +1035,7 @@ fn test_discovery_packet_unknown_framing_vector_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -1080,7 +1080,7 @@ fn test_discovery_packet_discovery_layer_wrong_flags_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -1103,7 +1103,7 @@ fn test_discovery_packet_discovery_layer_length_too_short_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(p) => {
             assert!(
@@ -1126,7 +1126,7 @@ fn test_discovery_packet_discovery_layer_length_too_long_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -1149,7 +1149,7 @@ fn test_discovery_packet_discovery_layer_vector_unknown_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -1172,7 +1172,7 @@ fn test_discovery_packet_page_higher_than_last_page_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -1195,7 +1195,7 @@ fn test_discovery_packet_decending_order_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -1218,7 +1218,7 @@ fn test_discovery_packet_random_order_parse() {
                     assert!(false, "Unexpected error type returned: {}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -1255,7 +1255,7 @@ fn generate_test_universe_discovery_packet(universes_to_generate: u16) -> Vec<u8
 
     let framing_layer_flags_length_upper: u8 = flags_val | framing_layer_parts[0];
     let framing_layer_flags_length_lower: u8 = framing_layer_parts[1];
-    
+
     // 22 as this is the number of bytes always in the root layer.
     // + the framing layer as the root layer encapsulates it.
     // As per ANSI E1.31-2018 Table 4-3: E1.31 Universe Discovery Packet Format.
@@ -1269,33 +1269,33 @@ fn generate_test_universe_discovery_packet(universes_to_generate: u16) -> Vec<u8
     let mut test_universe_discovery_packet = vec!{
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
-    0x00, 0x00, 
+    0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    root_layer_flags_length_upper, root_layer_flags_length_lower, 
+    root_layer_flags_length_upper, root_layer_flags_length_lower,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* E1.31 Framing Layer */
     /* Flags and Length */
-    framing_layer_flags_length_upper, framing_layer_flags_length_lower, 
+    framing_layer_flags_length_upper, framing_layer_flags_length_lower,
     /* Vector */
-    0x00, 0x00, 0x00, 0x02, 
+    0x00, 0x00, 0x00, 0x02,
     /* Source Name */
     b'S', b'o', b'u', b'r', b'c', b'e', b'_', b'A', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0,
     /* Reserved */
-    0, 0, 0, 0, 
+    0, 0, 0, 0,
     /* Universe Discovery Layer */
     /* Flags and Length */
     discovery_layer_flags_length_upper, discovery_layer_flags_length_lower,
     /* Vector */
-    0x00, 0x00, 0x00, 0x01, 
+    0x00, 0x00, 0x00, 0x01,
     /* Page */
     1,
     /* Last Page */

--- a/tests/ipv4_tests.rs
+++ b/tests/ipv4_tests.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(rustfmt, rustfmt_skip)]
 // Copyright 2020 sacn Developers
 //
 // Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or

--- a/tests/ipv6_tests.rs
+++ b/tests/ipv6_tests.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(rustfmt, rustfmt_skip)]
 // Copyright 2020 sacn Developers
 //
 // Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or

--- a/tests/src_tests.rs
+++ b/tests/src_tests.rs
@@ -188,7 +188,7 @@ fn test_get_cid() {
 
     let src = SacnSource::with_cid_ip("Test name", cid, SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), ACN_SDT_MULTICAST_PORT)).unwrap();
 
-    assert_eq!(src.cid().unwrap(), cid, "CID does not match CID set"); 
+    assert_eq!(src.cid().unwrap(), cid, "CID does not match CID set");
 }
 
 #[test]
@@ -201,7 +201,7 @@ fn test_set_get_cid() {
 
     src.set_cid(new_cid).unwrap();
 
-    assert_eq!(src.cid().unwrap(), new_cid, "CID does not match CID set"); 
+    assert_eq!(src.cid().unwrap(), new_cid, "CID does not match CID set");
 }
 
 #[test]
@@ -261,12 +261,12 @@ fn test_set_get_multicast_loop() {
 #[test]
 fn test_send_without_registering(){
     let mut src = SacnSource::new_v4("Controller").unwrap();
-    
+
     let priority = 100;
 
     match src.send(&[1], &TEST_DATA_SINGLE_UNIVERSE, Some(priority), None, None) {
         Ok(_) => {assert!(false, "Source didn't prevent sending without registering")},
-        Err(e) => 
+        Err(e) =>
             match e.kind() {
                 &ErrorKind::UniverseNotRegistered(ref _s) => assert!(true),
                 _ => assert!(false, "Unexpected error type returned, {}", e.kind())
@@ -274,13 +274,13 @@ fn test_send_without_registering(){
     }
 }
 
-/// Attempts to send a packet with a priority higher (> 200) than the maximum allowed as per ANSI E1.31-2018 Section 6.2.3. 
+/// Attempts to send a packet with a priority higher (> 200) than the maximum allowed as per ANSI E1.31-2018 Section 6.2.3.
 #[test]
 fn test_send_above_priority(){
     let mut src = SacnSource::new_v4("Controller").unwrap();
     let universe = 1;
     let priority = 201;
-    
+
     src.register_universe(universe).unwrap();
 
     match src.send(&[universe], &TEST_DATA_SINGLE_UNIVERSE, Some(priority), None, None) {
@@ -293,7 +293,7 @@ fn test_send_above_priority(){
                     assert!(false, "Unexpected error type returned, {:?}", x);
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -304,8 +304,8 @@ fn test_send_above_priority(){
     }
 }
 
-/// Tests sending a single universe of data, this appear 'assertion-free' but it isn't because .unwrap() will panic 
-/// if a function returns an error. 
+/// Tests sending a single universe of data, this appear 'assertion-free' but it isn't because .unwrap() will panic
+/// if a function returns an error.
 /// This test therefore checks that the sender works without crashing in one of the simplest cases.
 #[test]
 fn test_send_single_universe(){

--- a/tests/src_tests.rs
+++ b/tests/src_tests.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(rustfmt, rustfmt_skip)]
 // Copyright 2020 sacn Developers
 //
 // Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or

--- a/tests/sync_parse_tests.rs
+++ b/tests/sync_parse_tests.rs
@@ -17,26 +17,26 @@ use sacn::sacn_parse_pack_error::sacn_parse_pack_error;
 const TEST_SYNCHRONIZATION_PACKET: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
     0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x21, 
+    0x70, 0x21,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Synchronization Packet Framing Layer */
     /* Flags and Length */
-    0x70, 0x0b, 
+    0x70, 0x0b,
     /* Vector */
     0x00, 0x00, 0x00, 0x01,
     /* Sequence Number - Specifies a value of 367 which doesn't fit within a unsigned 8-bit byte, therefore used 367 % 0xff = 0x70 */
     0x70,
     /* Synchronization Address = 7962 */
-    0x1F, 0x1A, 
+    0x1F, 0x1A,
     /* Reserved */
     0, 0,
 ];
@@ -45,26 +45,26 @@ const TEST_SYNCHRONIZATION_PACKET: &[u8] = &[
 const TEST_SYNCHRONIZATION_PACKET_ROOT_LAYER_UNKNOWN_VECTOR: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
     0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x21, 
+    0x70, 0x21,
     /* Vector */
-    0x00, 0x00, 0x00, 0x09, 
+    0x00, 0x00, 0x00, 0x09,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Synchronization Packet Framing Layer */
     /* Flags and Length */
-    0x70, 0x0b, 
+    0x70, 0x0b,
     /* Vector */
     0x00, 0x00, 0x00, 0x01,
     /* Sequence Number - Specifies a value of 367 which doesn't fit within a unsigned 8-bit byte, therefore used 367 % 0xff = 0x70 */
     0x70,
     /* Synchronization Address = 7962 */
-    0x1F, 0x1A, 
+    0x1F, 0x1A,
     /* Reserved */
     0, 0,
 ];
@@ -73,26 +73,26 @@ const TEST_SYNCHRONIZATION_PACKET_ROOT_LAYER_UNKNOWN_VECTOR: &[u8] = &[
 const TEST_SYNCHRONIZATION_PACKET_ROOT_LAYER_DATA_VECTOR: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
     0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x21, 
+    0x70, 0x21,
     /* Vector */
-    0x00, 0x00, 0x00, 0x04, 
+    0x00, 0x00, 0x00, 0x04,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Synchronization Packet Framing Layer */
     /* Flags and Length */
-    0x70, 0x0b, 
+    0x70, 0x0b,
     /* Vector */
     0x00, 0x00, 0x00, 0x01,
     /* Sequence Number - Specifies a value of 367 which doesn't fit within a unsigned 8-bit byte, therefore used 367 % 0xff = 0x70 */
     0x70,
     /* Synchronization Address = 7962 */
-    0x1F, 0x1A, 
+    0x1F, 0x1A,
     /* Reserved */
     0, 0,
 ];
@@ -102,26 +102,26 @@ const TEST_SYNCHRONIZATION_PACKET_ROOT_LAYER_DATA_VECTOR: &[u8] = &[
 const TEST_SYNCHRONIZATION_PACKET_TOO_LONG_CID: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
     0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x21, 
+    0x70, 0x21,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e, 0x3e,
     /* Synchronization Packet Framing Layer */
     /* Flags and Length */
-    0x70, 0x0b, 
+    0x70, 0x0b,
     /* Vector */
     0x00, 0x00, 0x00, 0x01,
     /* Sequence Number - Specifies a value of 367 which doesn't fit within a unsigned 8-bit byte, therefore used 367 % 0xff = 0x70 */
     0x70,
     /* Synchronization Address = 7962 */
-    0x1F, 0x1A, 
+    0x1F, 0x1A,
     /* Reserved */
     0, 0,
 ];
@@ -131,26 +131,26 @@ const TEST_SYNCHRONIZATION_PACKET_TOO_LONG_CID: &[u8] = &[
 const TEST_SYNCHRONIZATION_PACKET_TOO_SHORT_CID: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
     0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x21, 
+    0x70, 0x21,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14,
     /* Synchronization Packet Framing Layer */
     /* Flags and Length */
-    0x70, 0x0b, 
+    0x70, 0x0b,
     /* Vector */
     0x00, 0x00, 0x00, 0x01,
     /* Sequence Number - Specifies a value of 367 which doesn't fit within a unsigned 8-bit byte, therefore used 367 % 0xff = 0x70 */
     0x70,
     /* Synchronization Address = 7962 */
-    0x1F, 0x1A, 
+    0x1F, 0x1A,
     /* Reserved */
     0, 0,
 ];
@@ -159,26 +159,26 @@ const TEST_SYNCHRONIZATION_PACKET_TOO_SHORT_CID: &[u8] = &[
 const TEST_SYNCHRONIZATION_PACKET_FRAMING_LAYER_WRONG_FLAGS: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
     0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x21, 
+    0x70, 0x21,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Synchronization Packet Framing Layer */
     /* Flags and Length */
-    0x60, 0x0b, 
+    0x60, 0x0b,
     /* Vector */
     0x00, 0x00, 0x00, 0x01,
     /* Sequence Number - Specifies a value of 367 which doesn't fit within a unsigned 8-bit byte, therefore used 367 % 0xff = 0x70 */
     0x70,
     /* Synchronization Address = 7962 */
-    0x1F, 0x1A, 
+    0x1F, 0x1A,
     /* Reserved */
     0, 0,
 ];
@@ -187,26 +187,26 @@ const TEST_SYNCHRONIZATION_PACKET_FRAMING_LAYER_WRONG_FLAGS: &[u8] = &[
 const TEST_SYNCHRONIZATION_PACKET_FRAMING_LAYER_LENGTH_TOO_LONG: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
     0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x21, 
+    0x70, 0x21,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Synchronization Packet Framing Layer */
     /* Flags and Length */
-    0x70, 0x0c, 
+    0x70, 0x0c,
     /* Vector */
     0x00, 0x00, 0x00, 0x01,
     /* Sequence Number - Specifies a value of 367 which doesn't fit within a unsigned 8-bit byte, therefore used 367 % 0xff = 0x70 */
     0x70,
     /* Synchronization Address = 7962 */
-    0x1F, 0x1A, 
+    0x1F, 0x1A,
     /* Reserved */
     0, 0,
 ];
@@ -215,26 +215,26 @@ const TEST_SYNCHRONIZATION_PACKET_FRAMING_LAYER_LENGTH_TOO_LONG: &[u8] = &[
 const TEST_SYNCHRONIZATION_PACKET_FRAMING_LAYER_LENGTH_TOO_SHORT: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
     0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x21, 
+    0x70, 0x21,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Synchronization Packet Framing Layer */
     /* Flags and Length */
-    0x70, 0x0a, 
+    0x70, 0x0a,
     /* Vector */
     0x00, 0x00, 0x00, 0x01,
     /* Sequence Number - Specifies a value of 367 which doesn't fit within a unsigned 8-bit byte, therefore used 367 % 0xff = 0x70 */
     0x70,
     /* Synchronization Address = 7962 */
-    0x1F, 0x1A, 
+    0x1F, 0x1A,
     /* Reserved */
     0, 0,
 ];
@@ -243,26 +243,26 @@ const TEST_SYNCHRONIZATION_PACKET_FRAMING_LAYER_LENGTH_TOO_SHORT: &[u8] = &[
 const TEST_SYNCHRONIZATION_PACKET_FRAMING_LAYER_DISCOVERY_VECTOR: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
     0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x21, 
+    0x70, 0x21,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Synchronization Packet Framing Layer */
     /* Flags and Length */
-    0x70, 0x0b, 
+    0x70, 0x0b,
     /* Vector */
     0x00, 0x00, 0x00, 0x02,
     /* Sequence Number - Specifies a value of 367 which doesn't fit within a unsigned 8-bit byte, therefore used 367 % 0xff = 0x70 */
     0x70,
     /* Synchronization Address = 7962 */
-    0x1F, 0x1A, 
+    0x1F, 0x1A,
     /* Reserved */
     0, 0,
 ];
@@ -271,26 +271,26 @@ const TEST_SYNCHRONIZATION_PACKET_FRAMING_LAYER_DISCOVERY_VECTOR: &[u8] = &[
 const TEST_SYNCHRONIZATION_PACKET_FRAMING_LAYER_UNKNOWN_VECTOR: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
     0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x21, 
+    0x70, 0x21,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Synchronization Packet Framing Layer */
     /* Flags and Length */
-    0x70, 0x0b, 
+    0x70, 0x0b,
     /* Vector */
     0x00, 0x00, 0x00, 0x07,
     /* Sequence Number - Specifies a value of 367 which doesn't fit within a unsigned 8-bit byte, therefore used 367 % 0xff = 0x70 */
     0x70,
     /* Synchronization Address = 7962 */
-    0x1F, 0x1A, 
+    0x1F, 0x1A,
     /* Reserved */
     0, 0,
 ];
@@ -300,20 +300,20 @@ const TEST_SYNCHRONIZATION_PACKET_FRAMING_LAYER_UNKNOWN_VECTOR: &[u8] = &[
 const TEST_SYNCHRONIZATION_PACKET_TOO_HIGH_SYNC_ADDRESS: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
     0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x21, 
+    0x70, 0x21,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Synchronization Packet Framing Layer */
     /* Flags and Length */
-    0x70, 0x0b, 
+    0x70, 0x0b,
     /* Vector */
     0x00, 0x00, 0x00, 0x01,
     /* Sequence Number - Specifies a value of 367 which doesn't fit within a unsigned 8-bit byte, therefore used 367 % 0xff = 0x70 */
@@ -329,20 +329,20 @@ const TEST_SYNCHRONIZATION_PACKET_TOO_HIGH_SYNC_ADDRESS: &[u8] = &[
 const TEST_SYNCHRONIZATION_PACKET_TOO_LOW_SYNC_ADDRESS: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
     0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x21, 
+    0x70, 0x21,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Synchronization Packet Framing Layer */
     /* Flags and Length */
-    0x70, 0x0b, 
+    0x70, 0x0b,
     /* Vector */
     0x00, 0x00, 0x00, 0x01,
     /* Sequence Number - Specifies a value of 367 which doesn't fit within a unsigned 8-bit byte, therefore used 367 % 0xff = 0x70 */
@@ -358,26 +358,26 @@ const TEST_SYNCHRONIZATION_PACKET_TOO_LOW_SYNC_ADDRESS: &[u8] = &[
 const TEST_SYNCHRONIZATION_PACKET_ARBITARY_RESERVED: &[u8] = &[
     /* Root Layer */
     /* Preamble Size */
-    0x00, 0x10, 
+    0x00, 0x10,
     /* Post-amble Size */
     0x00, 0x00,
     /* ACN Packet Identifier */
     0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
     /* Flags and Length Protocol */
-    0x70, 0x21, 
+    0x70, 0x21,
     /* Vector */
-    0x00, 0x00, 0x00, 0x08, 
+    0x00, 0x00, 0x00, 0x08,
     /* CID */
     0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
     /* Synchronization Packet Framing Layer */
     /* Flags and Length */
-    0x70, 0x0b, 
+    0x70, 0x0b,
     /* Vector */
     0x00, 0x00, 0x00, 0x01,
     /* Sequence Number - Specifies a value of 367 which doesn't fit within a unsigned 8-bit byte, therefore used 367 % 0xff = 0x70 */
     0x70,
     /* Synchronization Address = 7962 */
-    0x1F, 0x1A, 
+    0x1F, 0x1A,
     /* Reserved */
     255, 254,
 ];
@@ -425,7 +425,7 @@ fn test_sync_packet_root_layer_data_vector_parse() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -448,7 +448,7 @@ fn test_sync_packet_root_layer_unknown_vector_parse() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -473,7 +473,7 @@ fn test_sync_packet_too_short_cid_parse() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -498,7 +498,7 @@ fn test_sync_packet_too_long_cid_parse() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -521,7 +521,7 @@ fn test_sync_packet_framing_layer_wrong_flags_parse() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -544,7 +544,7 @@ fn test_sync_packet_framing_layer_length_too_long_parse() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -567,7 +567,7 @@ fn test_sync_packet_framing_layer_length_too_short_parse() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -593,7 +593,7 @@ fn test_sync_packet_framing_layer_discovery_vector() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -616,7 +616,7 @@ fn test_sync_packet_framing_layer_unknown_vector() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -639,7 +639,7 @@ fn test_sync_packet_too_high_sync_addr() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(
@@ -662,7 +662,7 @@ fn test_sync_packet_too_low_sync_addr() {
                     assert!(false, "Unexpected error type returned");
                 }
             }
-            
+
         }
         Ok(_) => {
             assert!(

--- a/tests/sync_parse_tests.rs
+++ b/tests/sync_parse_tests.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(rustfmt, rustfmt_skip)]
 extern crate sacn;
 extern crate uuid;
 


### PR DESCRIPTION
Applies rustfmt to all source code and removes trailing whitespaces.

`tests/*.rs` have byte-arrays with inline comments that get misaligned when rustfmt is applied, so (for now) rustfmt has been disabled on each of the test files.