### PR TITLE
refactor: update uuid and socket2 dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ exclude = [
 
 [dependencies]
 byteorder = { version = "1.5.0", features = [] }
-socket2 = { version = "0.3.4", features = ["reuseport"] }
-libc = { version = "0.2.171" } 
 error-chain = "0.12.4"
-uuid = { version = "0.6.3", features = ["use_std", "v4"] }
+libc = { version = "0.2.171" }
+socket2 = { version = "0.5.9", features = ["all"] }
+uuid = { version = "1.12", features = ["v4"] }
 
 [dev-dependencies]
 crossterm = "0.29.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,7 +34,7 @@ pub mod errors {
         foreign_links {
             Io(::std::io::Error);       // Allow IO errors to be used with the error-chain system.
             Str(::std::str::Utf8Error); // Allow standard string library errors to be used with the error-chain system.
-            Uuid(uuid::ParseError);     // Allow UUID library to be used with error-chain system. 
+            Uuid(uuid::Error);     // Allow UUID library to be used with error-chain system.
         }
 
         links {

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -234,13 +234,16 @@ const E131_POSTAMBLE_SIZE: u16 = 0x0;
 
 /// The E131 ACN packet identifier field value. Must be 0x41 0x53 0x43 0x2d 0x45 0x31 0x2e 0x31 0x37 0x00 0x00 0x00 as per
 /// ANSI E1.31-2018 Section 5.3.
-const E131_ACN_PACKET_IDENTIFIER: [u8; 12] = [0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00];
+const E131_ACN_PACKET_IDENTIFIER: [u8; 12] = [
+    0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
+];
 
 /// The E131 CID field length in bytes as per ANSI E1.31-2018 Section 4 Table 4-1, 4-2, 4-3.
 pub const E131_CID_FIELD_LENGTH: usize = 16;
 
 // The exclusive end index of the CID field. Calculated based on previous values defined in ANSI E1.31-2018 Section 4 Table 4-1, 4-2, 4-3.
-const E131_CID_END_INDEX: usize = E131_PDU_LENGTH_FLAGS_LENGTH + E131_ROOT_LAYER_VECTOR_LENGTH + E131_CID_FIELD_LENGTH;
+const E131_CID_END_INDEX: usize =
+    E131_PDU_LENGTH_FLAGS_LENGTH + E131_ROOT_LAYER_VECTOR_LENGTH + E131_CID_FIELD_LENGTH;
 
 /// The length of the Source Name field in bytes in an ANSI E1.31-2018 packet as per ANSI E1.31-2018 Section 4, Table 4-1, 4-2, 4-3.
 pub const E131_SOURCE_NAME_FIELD_LENGTH: usize = 64;
@@ -411,7 +414,11 @@ fn parse_source_name_str(buf: &[u8]) -> Result<&str> {
     }
 
     if source_name_length == buf.len() && buf[buf.len() - 1] != 0 {
-        bail!(ErrorKind::SacnParsePackError(sacn_parse_pack_error::ErrorKind::SourceNameInvalid("Packet source name not null terminated".to_string())));
+        bail!(ErrorKind::SacnParsePackError(
+            sacn_parse_pack_error::ErrorKind::SourceNameInvalid(
+                "Packet source name not null terminated".to_string()
+            )
+        ));
     }
 
     Ok(str::from_utf8(&buf[..source_name_length])?)
@@ -531,19 +538,26 @@ struct PduInfo {
 /// 
 fn pdu_info(buf: &[u8], vector_length: usize) -> Result<PduInfo> {
     if buf.len() < E131_PDU_LENGTH_FLAGS_LENGTH + vector_length {
-        bail!(ErrorKind::SacnParsePackError(sacn_parse_pack_error::ErrorKind::ParseInsufficientData("Insufficient data when parsing pdu_info, no flags or length field".to_string())));
+        bail!(ErrorKind::SacnParsePackError(
+            sacn_parse_pack_error::ErrorKind::ParseInsufficientData(
+                "Insufficient data when parsing pdu_info, no flags or length field".to_string()
+            )
+        ));
     }
 
     // Flags
     let flags = buf[0] & 0xf0; // Flags are stored in the top 4 bits.
     if flags != E131_PDU_FLAGS {
-        bail!(ErrorKind::SacnParsePackError(sacn_parse_pack_error::ErrorKind::ParsePduInvalidFlags(flags)));
+        bail!(ErrorKind::SacnParsePackError(
+            sacn_parse_pack_error::ErrorKind::ParsePduInvalidFlags(flags)
+        ));
     }
     // Length
     let length = (NetworkEndian::read_u16(&buf[0 .. E131_PDU_LENGTH_FLAGS_LENGTH]) & 0x0fff) as usize;
 
     // Vector
-    let vector = NetworkEndian::read_uint(&buf[E131_PDU_LENGTH_FLAGS_LENGTH .. ], vector_length) as u32;
+    let vector =
+        NetworkEndian::read_uint(&buf[E131_PDU_LENGTH_FLAGS_LENGTH..], vector_length) as u32;
 
     Ok(PduInfo { length, vector })
 }
@@ -593,7 +607,7 @@ macro_rules! impl_e131_root_layer {
                 }
                 
                 // CID
-                let cid = Uuid::from_bytes(&buf[E131_PDU_LENGTH_FLAGS_LENGTH + E131_ROOT_LAYER_VECTOR_LENGTH .. E131_CID_END_INDEX])?;
+                let cid = Uuid::from_slice(&buf[E131_PDU_LENGTH_FLAGS_LENGTH + E131_ROOT_LAYER_VECTOR_LENGTH .. E131_CID_END_INDEX])?;
 
                 // Data
                 let data = match vector {
@@ -1069,13 +1083,16 @@ pub struct SynchronizationPacketFramingLayer {
 // Constants are replaced inline so this increases readability by removing magic numbers without affecting runtime performance.
 // Theses indexes are only valid within the scope of this part of the protocol (SynchronisationPacketFramingLayer).
 const E131_SYNC_FRAMING_LAYER_VECTOR_FIELD_INDEX: usize = E131_PDU_LENGTH_FLAGS_LENGTH;
-const E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_INDEX: usize = E131_SYNC_FRAMING_LAYER_VECTOR_FIELD_INDEX + E131_FRAMING_LAYER_VECTOR_LENGTH;
-const E131_SYNC_FRAMING_LAYER_SYNC_ADDRESS_FIELD_INDEX: usize = E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_INDEX + E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_LENGTH;
-const E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX: usize = E131_SYNC_FRAMING_LAYER_SYNC_ADDRESS_FIELD_INDEX + E131_SYNC_ADDR_FIELD_LENGTH;
-const E131_SYNC_FRAMING_LAYER_END_INDEX: usize = E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX + E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_LENGTH;
+const E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_INDEX: usize =
+    E131_SYNC_FRAMING_LAYER_VECTOR_FIELD_INDEX + E131_FRAMING_LAYER_VECTOR_LENGTH;
+const E131_SYNC_FRAMING_LAYER_SYNC_ADDRESS_FIELD_INDEX: usize =
+    E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_INDEX + E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_LENGTH;
+const E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX: usize =
+    E131_SYNC_FRAMING_LAYER_SYNC_ADDRESS_FIELD_INDEX + E131_SYNC_ADDR_FIELD_LENGTH;
+const E131_SYNC_FRAMING_LAYER_END_INDEX: usize =
+    E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX + E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_LENGTH;
 
 impl Pdu for SynchronizationPacketFramingLayer {
-
     fn parse(buf: &[u8]) -> Result<SynchronizationPacketFramingLayer> {
         // Length and Vector
         let PduInfo { length, vector } = pdu_info(&buf, E131_FRAMING_LAYER_VECTOR_LENGTH)?;
@@ -1084,26 +1101,38 @@ impl Pdu for SynchronizationPacketFramingLayer {
         }
 
         if vector != VECTOR_E131_EXTENDED_SYNCHRONIZATION {
-            bail!(ErrorKind::SacnParsePackError(sacn_parse_pack_error::ErrorKind::PduInvalidVector(vector)));
+            bail!(ErrorKind::SacnParsePackError(
+                sacn_parse_pack_error::ErrorKind::PduInvalidVector(vector)
+            ));
         }
 
         if length != E131_UNIVERSE_SYNC_PACKET_FRAMING_LAYER_LENGTH {
             bail!(ErrorKind::SacnParsePackError(
-                sacn_parse_pack_error::ErrorKind::PduInvalidLength(length))); 
+                sacn_parse_pack_error::ErrorKind::PduInvalidLength(length)
+            ));
         }
 
         // Sequence Number
         let sequence_number = buf[E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_INDEX];
 
         // Synchronization Address
-        let synchronization_address = NetworkEndian::read_u16(&buf[E131_SYNC_FRAMING_LAYER_SYNC_ADDRESS_FIELD_INDEX .. E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX]);
-
-        if synchronization_address > E131_MAX_MULTICAST_UNIVERSE || synchronization_address < E131_MIN_MULTICAST_UNIVERSE {
-            bail!(
-                ErrorKind::SacnParsePackError(
-                sacn_parse_pack_error::ErrorKind::ParseInvalidUniverse(
-                    format!("Synchronisation address value: {} is outwith the allowed range", synchronization_address).to_string()))
+        let synchronization_address = NetworkEndian::read_u16(
+            &buf[E131_SYNC_FRAMING_LAYER_SYNC_ADDRESS_FIELD_INDEX
+                ..E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX],
             );
+
+        if synchronization_address > E131_MAX_MULTICAST_UNIVERSE
+            || synchronization_address < E131_MIN_MULTICAST_UNIVERSE
+        {
+            bail!(ErrorKind::SacnParsePackError(
+                sacn_parse_pack_error::ErrorKind::ParseInvalidUniverse(
+                    format!(
+                        "Synchronisation address value: {} is outwith the allowed range",
+                        synchronization_address
+                    )
+                    .to_string()
+                )
+            ));
         }
 
         // Reserved fields (2 bytes right immediately after the synchronisation address) should be ignored by receivers as per 
@@ -1117,24 +1146,41 @@ impl Pdu for SynchronizationPacketFramingLayer {
 
     fn pack(&self, buf: &mut [u8]) -> Result<()> {
         if buf.len() < self.len() {
-            bail!(ErrorKind::SacnParsePackError(sacn_parse_pack_error::ErrorKind::PackBufferInsufficient("SynchronizationPacketFramingLayer pack buffer length insufficient".to_string())));
+            bail!(ErrorKind::SacnParsePackError(
+                sacn_parse_pack_error::ErrorKind::PackBufferInsufficient(
+                    "SynchronizationPacketFramingLayer pack buffer length insufficient".to_string()
+                )
+            ));
         }
 
         // Flags and Length
-        let flags_and_length = NetworkEndian::read_u16(&[E131_PDU_FLAGS, 0x0]) | (self.len() as u16) & 0x0fff;
+        let flags_and_length =
+            NetworkEndian::read_u16(&[E131_PDU_FLAGS, 0x0]) | (self.len() as u16) & 0x0fff;
         NetworkEndian::write_u16(&mut buf[0.. E131_PDU_LENGTH_FLAGS_LENGTH], flags_and_length);
 
         // Vector
-        NetworkEndian::write_u32(&mut buf[E131_SYNC_FRAMING_LAYER_VECTOR_FIELD_INDEX .. E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_INDEX], VECTOR_E131_EXTENDED_SYNCHRONIZATION);
+        NetworkEndian::write_u32(
+            &mut buf[E131_SYNC_FRAMING_LAYER_VECTOR_FIELD_INDEX
+                ..E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_INDEX],
+            VECTOR_E131_EXTENDED_SYNCHRONIZATION,
+        );
 
         // Sequence Number
         buf[E131_SYNC_FRAMING_LAYER_SEQ_NUM_FIELD_INDEX] = self.sequence_number;
 
         // Synchronization Address
-        NetworkEndian::write_u16(&mut buf[E131_SYNC_FRAMING_LAYER_SYNC_ADDRESS_FIELD_INDEX .. E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX], self.synchronization_address);
+        NetworkEndian::write_u16(
+            &mut buf[E131_SYNC_FRAMING_LAYER_SYNC_ADDRESS_FIELD_INDEX
+                ..E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX],
+            self.synchronization_address,
+        );
 
         // Reserved, transmitted as zeros as per ANSI E1.31-2018 Section 6.3.4.
-        zeros(&mut buf[E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX .. E131_SYNC_FRAMING_LAYER_END_INDEX], E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_LENGTH);
+        zeros(
+            &mut buf
+                [E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_INDEX..E131_SYNC_FRAMING_LAYER_END_INDEX],
+            E131_SYNC_FRAMING_LAYER_RESERVE_FIELD_LENGTH,
+        );
 
         Ok(())
     }
@@ -1430,7 +1476,8 @@ fn parse_universe_list<'a>(buf: &[u8], length: usize) -> Result<Cow<'a, [u16]>> 
     while i < (length * E131_UNIVERSE_FIELD_LENGTH)  {
         let u = NetworkEndian::read_u16(&buf[i .. i + E131_UNIVERSE_FIELD_LENGTH]);
 
-        if (u as i32) > last_universe { // Enforce assending ordering of universes as per ANSI E1.31-2018 Section 8.5. 
+        if (u as i32) > last_universe {
+            // Enforce assending ordering of universes as per ANSI E1.31-2018 Section 8.5.
             universes.push(u);
             last_universe = u as i32;
             i = i + E131_UNIVERSE_FIELD_LENGTH; // Jump to the next universe.
@@ -1457,10 +1504,10 @@ mod test {
     fn test_universe_to_ipv4_lowest_byte_normal() {
         let val: u16 = 119;
         let res = universe_to_ipv4_multicast_addr(val).unwrap();
-        assert!(res.as_inet().unwrap().ip().is_multicast());
+        assert!(res.as_socket_ipv4().unwrap().ip().is_multicast());
 
         assert_eq!(
-            res.as_inet().unwrap(),
+            res.as_socket_ipv4().unwrap(),
             SocketAddrV4::new(
                 Ipv4Addr::new(239, 255, (val / 256) as u8, (val % 256) as u8),
                 ACN_SDT_MULTICAST_PORT
@@ -1472,10 +1519,10 @@ mod test {
     fn test_universe_to_ip_ipv4_both_bytes_normal() {
         let val: u16 = 300;
         let res = universe_to_ipv4_multicast_addr(val).unwrap();
-        assert!(res.as_inet().unwrap().ip().is_multicast());
+        assert!(res.as_socket_ipv4().unwrap().ip().is_multicast());
 
         assert_eq!(
-            res.as_inet().unwrap(),
+            res.as_socket_ipv4().unwrap(),
             SocketAddrV4::new(
                 Ipv4Addr::new(239, 255, (val / 256) as u8, (val % 256) as u8),
                 ACN_SDT_MULTICAST_PORT
@@ -1486,10 +1533,10 @@ mod test {
     #[test]
     fn test_universe_to_ip_ipv4_limit_high() {
         let res = universe_to_ipv4_multicast_addr(E131_MAX_MULTICAST_UNIVERSE).unwrap();
-        assert!(res.as_inet().unwrap().ip().is_multicast());
+        assert!(res.as_socket_ipv4().unwrap().ip().is_multicast());
 
         assert_eq!(
-            res.as_inet().unwrap(),
+            res.as_socket_ipv4().unwrap(),
             SocketAddrV4::new(
                 Ipv4Addr::new(
                     239,
@@ -1506,10 +1553,10 @@ mod test {
     fn test_universe_to_ip_ipv4_limit_low() {
         let res = universe_to_ipv4_multicast_addr(E131_MIN_MULTICAST_UNIVERSE).unwrap();
 
-        assert!(res.as_inet().unwrap().ip().is_multicast());
+        assert!(res.as_socket_ipv4().unwrap().ip().is_multicast());
 
         assert_eq!(
-            res.as_inet().unwrap(),
+            res.as_socket_ipv4().unwrap(),
             SocketAddrV4::new(
                 Ipv4Addr::new(
                     239,
@@ -1555,12 +1602,12 @@ mod test {
         let val: u16 = 119;
         let res = universe_to_ipv6_multicast_addr(val).unwrap();
 
-        assert!(res.as_inet6().unwrap().ip().is_multicast());
+        assert!(res.as_socket_ipv6().unwrap().ip().is_multicast());
 
         let low_16: u16 = (((val / 256) as u16) << 8) | ((val % 256) as u16);
 
         assert_eq!(
-            res.as_inet6().unwrap(),
+            res.as_socket_ipv6().unwrap(),
             SocketAddrV6::new(
                 Ipv6Addr::new(0xFF18, 0, 0, 0, 0, 0, 0x8300, low_16),
                 ACN_SDT_MULTICAST_PORT,
@@ -1575,12 +1622,12 @@ mod test {
         let val: u16 = 300;
         let res = universe_to_ipv6_multicast_addr(val).unwrap();
 
-        assert!(res.as_inet6().unwrap().ip().is_multicast());
+        assert!(res.as_socket_ipv6().unwrap().ip().is_multicast());
 
         let low_16: u16 = (((val / 256) as u16) << 8) | ((val % 256) as u16);
 
         assert_eq!(
-            res.as_inet6().unwrap(),
+            res.as_socket_ipv6().unwrap(),
             SocketAddrV6::new(
                 Ipv6Addr::new(0xFF18, 0, 0, 0, 0, 0, 0x8300, low_16),
                 ACN_SDT_MULTICAST_PORT,
@@ -1594,13 +1641,13 @@ mod test {
     fn test_universe_to_ip_ipv6_limit_high() {
         let res = universe_to_ipv6_multicast_addr(E131_MAX_MULTICAST_UNIVERSE).unwrap();
 
-        assert!(res.as_inet6().unwrap().ip().is_multicast());
+        assert!(res.as_socket_ipv6().unwrap().ip().is_multicast());
 
         let low_16: u16 = (((E131_MAX_MULTICAST_UNIVERSE / 256) as u16) << 8)
             | ((E131_MAX_MULTICAST_UNIVERSE % 256) as u16);
 
         assert_eq!(
-            res.as_inet6().unwrap(),
+            res.as_socket_ipv6().unwrap(),
             SocketAddrV6::new(
                 Ipv6Addr::new(0xFF18, 0, 0, 0, 0, 0, 0x8300, low_16),
                 ACN_SDT_MULTICAST_PORT,
@@ -1614,13 +1661,13 @@ mod test {
     fn test_universe_to_ip_ipv6_limit_low() {
         let res = universe_to_ipv6_multicast_addr(E131_MIN_MULTICAST_UNIVERSE).unwrap();
 
-        assert!(res.as_inet6().unwrap().ip().is_multicast());
+        assert!(res.as_socket_ipv6().unwrap().ip().is_multicast());
 
         let low_16: u16 = (((E131_MIN_MULTICAST_UNIVERSE / 256) as u16) << 8)
             | ((E131_MIN_MULTICAST_UNIVERSE % 256) as u16);
 
         assert_eq!(
-            res.as_inet6().unwrap(),
+            res.as_socket_ipv6().unwrap(),
             SocketAddrV6::new(
                 Ipv6Addr::new(0xFF18, 0, 0, 0, 0, 0, 0x8300, low_16),
                 ACN_SDT_MULTICAST_PORT,

--- a/src/receive.rs
+++ b/src/receive.rs
@@ -34,6 +34,7 @@ use std::borrow::Cow;
 use std::cmp::{max, Ordering};
 use std::collections::HashMap;
 use std::fmt;
+use std::io::Read;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::time::{Duration, Instant};
 
@@ -1203,10 +1204,10 @@ impl SacnNetworkReceiver {
     /// May return an error if there is an issue parsing the data from the underlying socket, see (parse)[fn.AcnRootLayerProtocol::parse.packet].
     ///
     fn recv<'a>(
-        &self,
+        &mut self,
         buf: &'a mut [u8; RCV_BUF_DEFAULT_SIZE],
     ) -> Result<AcnRootLayerProtocol<'a>> {
-        self.socket.recv(&mut buf[0..])?;
+        self.socket.read_exact(buf)?;
 
         Ok(AcnRootLayerProtocol::parse(buf)?)
     }
@@ -1356,10 +1357,10 @@ impl SacnNetworkReceiver {
     /// May return an error if there is an issue parsing the data from the underlying socket, see (parse)[fn.AcnRootLayerProtocol::parse.packet].
     ///
     fn recv<'a>(
-        &self,
+        &mut self,
         buf: &'a mut [u8; RCV_BUF_DEFAULT_SIZE],
     ) -> Result<AcnRootLayerProtocol<'a>> {
-        self.socket.recv(&mut buf[0..])?;
+        self.socket.read_exact(buf)?;
 
         Ok(AcnRootLayerProtocol::parse(buf)?)
     }
@@ -1474,7 +1475,7 @@ impl DiscoveredSacnSource {
 #[cfg(not(target_os = "windows"))]
 fn create_unix_socket(addr: SocketAddr) -> Result<Socket> {
     if addr.is_ipv4() {
-        let socket = Socket::new(Domain::ipv4(), Type::dgram(), Some(Protocol::udp()))?;
+        let socket = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))?;
 
         // Multiple different processes might want to listen to the sACN stream so therefore need to allow re-using the ACN port.
         socket.set_reuse_port(true)?;
@@ -1485,7 +1486,7 @@ fn create_unix_socket(addr: SocketAddr) -> Result<Socket> {
         socket.bind(&socket_addr.into())?;
         Ok(socket)
     } else {
-        let socket = Socket::new(Domain::ipv6(), Type::dgram(), Some(Protocol::udp()))?;
+        let socket = Socket::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP))?;
 
         // Multiple different processes might want to listen to the sACN stream so therefore need to allow re-using the ACN port.
         socket.set_reuse_port(true)?;
@@ -1514,7 +1515,7 @@ fn create_unix_socket(addr: SocketAddr) -> Result<Socket> {
 fn join_unix_multicast(socket: &Socket, addr: SockAddr, interface_addr: IpAddr) -> Result<()> {
     match addr.family() as i32 {
         // Cast required because AF_INET is defined in libc in terms of a c_int (i32) but addr.family returns using u16.
-        AF_INET => match addr.as_inet() {
+        AF_INET => match addr.as_socket_ipv4() {
             Some(a) => match interface_addr {
                 IpAddr::V4(ref interface_v4) => {
                     socket
@@ -1531,7 +1532,7 @@ fn join_unix_multicast(socket: &Socket, addr: SockAddr, interface_addr: IpAddr) 
                 bail!(ErrorKind::UnsupportedIpVersion("IP version recognised as AF_INET but not actually usable as AF_INET so must be unknown type".to_string()));
             }
         },
-        AF_INET6 => match addr.as_inet6() {
+        AF_INET6 => match addr.as_socket_ipv6() {
             Some(a) => {
                 socket
                     .join_multicast_v6(a.ip(), 0)
@@ -1565,7 +1566,7 @@ fn join_unix_multicast(socket: &Socket, addr: SockAddr, interface_addr: IpAddr) 
 fn leave_unix_multicast(socket: &Socket, addr: SockAddr, interface_addr: IpAddr) -> Result<()> {
     match addr.family() as i32 {
         // Cast required because AF_INET is defined in libc in terms of a c_int (i32) but addr.family returns using u16.
-        AF_INET => match addr.as_inet() {
+        AF_INET => match addr.as_socket_ipv4() {
             Some(a) => match interface_addr {
                 IpAddr::V4(ref interface_v4) => {
                     socket
@@ -1582,7 +1583,7 @@ fn leave_unix_multicast(socket: &Socket, addr: SockAddr, interface_addr: IpAddr)
                 bail!(ErrorKind::UnsupportedIpVersion("IP version recognised as AF_INET but not actually usable as AF_INET so must be unknown type".to_string()));
             }
         },
-        AF_INET6 => match addr.as_inet6() {
+        AF_INET6 => match addr.as_socket_ipv6() {
             Some(a) => {
                 socket
                     .leave_multicast_v6(a.ip(), 0)
@@ -2621,11 +2622,10 @@ mod test {
 
         dmx_rcv.listen_universes(&[UNIVERSE1]).unwrap();
 
-        let src_cid: Uuid = Uuid::from_bytes(&[
+        let src_cid: Uuid = Uuid::from_bytes([
             0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6,
             0x14, 0x3e,
-        ])
-        .unwrap();
+        ]);
 
         let data_packet = generate_data_packet_framing_layer_seq_num(UNIVERSE1, 0);
         let data_packet2 = generate_data_packet_framing_layer_seq_num(UNIVERSE1, 1);
@@ -2659,7 +2659,11 @@ mod test {
                 assert!(false, "Receiver incorrectly accepted third data packet");
             }
             Err(e) => {
-                assert!(false, "Receiver correctly rejected third data packet but with unexpected error: {}", e);
+                assert!(
+                    false,
+                    "Receiver correctly rejected third data packet but with unexpected error: {}",
+                    e
+                );
             }
         }
     }
@@ -2692,11 +2696,10 @@ mod test {
         // The exclusive lower bound on the diff values (new_packet_seq_num - last_packet_seq_num) that will be rejected.
         const REJECT_RANGE_LOWER_BOUND: i16 = -20;
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), ACN_SDT_MULTICAST_PORT);
-        let src_cid: Uuid = Uuid::from_bytes(&[
+        let src_cid: Uuid = Uuid::from_bytes([
             0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6,
             0x14, 0x3e,
-        ])
-        .unwrap();
+        ]);
 
         for i in SEQ_NUM_LOWER_BOUND..SEQ_NUM_UPPER_BOUND {
             // Create the receiver.
@@ -2803,11 +2806,10 @@ mod test {
         // The exclusive lower bound on the diff values (new_packet_seq_num - last_packet_seq_num) that will be rejected.
         const REJECT_RANGE_LOWER_BOUND: i16 = -20;
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), ACN_SDT_MULTICAST_PORT);
-        let src_cid: Uuid = Uuid::from_bytes(&[
+        let src_cid: Uuid = Uuid::from_bytes([
             0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6,
             0x14, 0x3e,
-        ])
-        .unwrap();
+        ]);
 
         for i in SEQ_NUM_LOWER_BOUND..SEQ_NUM_UPPER_BOUND {
             // Create the receiver.
@@ -2899,11 +2901,10 @@ mod test {
 
         dmx_rcv.listen_universes(&[UNIVERSE1]).unwrap();
 
-        let src_cid: Uuid = Uuid::from_bytes(&[
+        let src_cid: Uuid = Uuid::from_bytes([
             0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6,
             0x14, 0x3e,
-        ])
-        .unwrap();
+        ]);
 
         let sync_packet = generate_sync_packet_framing_layer_seq_num(UNIVERSE1, 0);
         let sync_packet2 = generate_sync_packet_framing_layer_seq_num(UNIVERSE1, 1);
@@ -2937,7 +2938,11 @@ mod test {
                 assert!(false, "Receiver incorrectly accepted third sync packet");
             }
             Err(e) => {
-                assert!(false, "Receiver correctly rejected third sync packet but with unexpected error: {}", e);
+                assert!(
+                    false,
+                    "Receiver correctly rejected third sync packet but with unexpected error: {}",
+                    e
+                );
             }
         }
     }
@@ -2957,11 +2962,10 @@ mod test {
 
         dmx_rcv.listen_universes(&[UNIVERSE1]).unwrap();
 
-        let src_cid: Uuid = Uuid::from_bytes(&[
+        let src_cid: Uuid = Uuid::from_bytes([
             0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6,
             0x14, 0x3e,
-        ])
-        .unwrap();
+        ]);
 
         let sync_packet = generate_sync_packet_framing_layer_seq_num(UNIVERSE1, 0);
         let sync_packet2 = generate_sync_packet_framing_layer_seq_num(UNIVERSE1, 1);
@@ -3010,11 +3014,10 @@ mod test {
 
         dmx_rcv.listen_universes(&[UNIVERSE1]).unwrap();
 
-        let src_cid: Uuid = Uuid::from_bytes(&[
+        let src_cid: Uuid = Uuid::from_bytes([
             0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6,
             0x14, 0x3e,
-        ])
-        .unwrap();
+        ]);
 
         let data_packet = generate_data_packet_framing_layer_seq_num(UNIVERSE1, 0);
         let data_packet2 = generate_data_packet_framing_layer_seq_num(UNIVERSE1, 1);
@@ -3064,11 +3067,10 @@ mod test {
 
         dmx_rcv.listen_universes(&[UNIVERSE]).unwrap();
 
-        let src_cid: Uuid = Uuid::from_bytes(&[
+        let src_cid: Uuid = Uuid::from_bytes([
             0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6,
             0x14, 0x3e,
-        ])
-        .unwrap();
+        ]);
 
         let data_packet = generate_data_packet_framing_layer_seq_num(UNIVERSE, 0);
         let data_packet2 = generate_data_packet_framing_layer_seq_num(UNIVERSE, 1);
@@ -3119,11 +3121,10 @@ mod test {
 
         dmx_rcv.listen_universes(&[UNIVERSE1, UNIVERSE2]).unwrap();
 
-        let src_cid: Uuid = Uuid::from_bytes(&[
+        let src_cid: Uuid = Uuid::from_bytes([
             0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6,
             0x14, 0x3e,
-        ])
-        .unwrap();
+        ]);
 
         let data_packet = generate_data_packet_framing_layer_seq_num(UNIVERSE1, 0);
         let data_packet2 = generate_data_packet_framing_layer_seq_num(UNIVERSE1, 1);
@@ -3175,11 +3176,10 @@ mod test {
             .listen_universes(&[SYNC_ADDR_1, SYNC_ADDR_2])
             .unwrap();
 
-        let src_cid: Uuid = Uuid::from_bytes(&[
+        let src_cid: Uuid = Uuid::from_bytes([
             0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6,
             0x14, 0x3e,
-        ])
-        .unwrap();
+        ]);
 
         let sync_packet = generate_sync_packet_framing_layer_seq_num(SYNC_ADDR_1, 0);
         let sync_packet2 = generate_sync_packet_framing_layer_seq_num(SYNC_ADDR_1, 1);
@@ -3218,25 +3218,24 @@ mod test {
         let source_limit: Option<usize> = Some(0);
 
         match SacnReceiver::with_ip(addr, source_limit) {
-            Err(e) => {
-                match e.kind() {
-                    ErrorKind::Io(x) => {
-                        match x.kind() {
+            Err(e) => match e.kind() {
+                ErrorKind::Io(x) => match x.kind() {
                             std::io::ErrorKind::InvalidInput => {
                                 assert!(true, "Correct error returned");
                             }
                             _ => {
                                 assert!(false, "Expected error returned");
                             }
-                        }
-                    }
+                },
                     _ => {
                         assert!(false, "Unexpected error type returned");
                     }
-                }
-            }
+            },
             _ => {
-                assert!(false, "SacnReceiver accepted 0 source limit when it shouldn't");
+                assert!(
+                    false,
+                    "SacnReceiver accepted 0 source limit when it shouldn't"
+                );
             }
         }
     }
@@ -3246,7 +3245,10 @@ mod test {
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), ACN_SDT_MULTICAST_PORT);
         let dmx_rcv = SacnReceiver::with_ip(addr, None).unwrap();
 
-        assert!(dmx_rcv.is_multicast_enabled(), "Multicast not enabled by default");
+        assert!(
+            dmx_rcv.is_multicast_enabled(),
+            "Multicast not enabled by default"
+        );
     }
 
     #[test]
@@ -3256,7 +3258,10 @@ mod test {
 
         dmx_rcv.set_is_multicast_enabled(false).unwrap();
 
-        assert!(!dmx_rcv.is_multicast_enabled(), "Multicast not disabled correctly");
+        assert!(
+            !dmx_rcv.is_multicast_enabled(),
+            "Multicast not disabled correctly"
+        );
     }
 
     #[test]
@@ -3280,7 +3285,11 @@ mod test {
 
         dmx_rcv.clear_all_waiting_data();
 
-        assert_eq!(dmx_rcv.rtrv_waiting_data(SYNC_ADDR), Vec::new(), "Data was not reset as expected");
+        assert_eq!(
+            dmx_rcv.rtrv_waiting_data(SYNC_ADDR),
+            Vec::new(),
+            "Data was not reset as expected"
+        );
     }
 
     #[test]
@@ -3288,7 +3297,10 @@ mod test {
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), ACN_SDT_MULTICAST_PORT);
         let dmx_rcv = SacnReceiver::with_ip(addr, None).unwrap();
 
-        assert!(!dmx_rcv.get_announce_source_discovery(), "Announce source discovery is true by default when should be false");
+        assert!(
+            !dmx_rcv.get_announce_source_discovery(),
+            "Announce source discovery is true by default when should be false"
+        );
     }
 
     #[test]
@@ -3296,7 +3308,10 @@ mod test {
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), ACN_SDT_MULTICAST_PORT);
         let dmx_rcv = SacnReceiver::with_ip(addr, None).unwrap();
 
-        assert!(!dmx_rcv.get_announce_timeout(), "Announce timeout flag is true by default when should be false");
+        assert!(
+            !dmx_rcv.get_announce_timeout(),
+            "Announce timeout flag is true by default when should be false"
+        );
     }
 
     #[test]
@@ -3304,7 +3319,10 @@ mod test {
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), ACN_SDT_MULTICAST_PORT);
         let dmx_rcv = SacnReceiver::with_ip(addr, None).unwrap();
 
-        assert!(!dmx_rcv.get_announce_stream_termination(), "Announce termination flag is true by default when should be false");
+        assert!(
+            !dmx_rcv.get_announce_stream_termination(),
+            "Announce termination flag is true by default when should be false"
+        );
     }
 
     /// Tests handling a sync packet for a synchronisation address which isn't currently being listened to.
@@ -3313,10 +3331,15 @@ mod test {
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), ACN_SDT_MULTICAST_PORT);
         let mut dmx_rcv = SacnReceiver::with_ip(addr, None).unwrap();
 
-        let res = dmx_rcv.handle_sync_packet(Uuid::new_v4(), SynchronizationPacketFramingLayer{
+        let res = dmx_rcv
+            .handle_sync_packet(
+                Uuid::new_v4(),
+                SynchronizationPacketFramingLayer {
             sequence_number: 0,
-            synchronization_address: 1
-        }).unwrap(); // Checks that no error is produced.
+                    synchronization_address: 1,
+                },
+            )
+            .unwrap(); // Checks that no error is produced.
 
         assert_eq!(res, None, "Sync packet produced output when should have been ignored as for an address that isn't being listened to");
     }
@@ -3325,7 +3348,7 @@ mod test {
     #[test]
     fn test_dmx_data_eq() {
         const UNIVERSE: u16 = 1;
-        let values: Vec<u8> = vec!(1,2,3);
+        let values: Vec<u8> = vec![1, 2, 3];
         const SYNC_ADDR: u16 = 1;
         const PRIORITY: u8 = 100;
         const PREVIEW: bool = false;
@@ -3354,6 +3377,9 @@ mod test {
             recv_timestamp: Instant::now(),
         };
 
-        assert_eq!(data1, data2, "DMX data not seen as equivalent when should be");
+        assert_eq!(
+            data1, data2,
+            "DMX data not seen as equivalent when should be"
+        );
     }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -14,21 +14,21 @@
 // of each public item without relying on referring to private items.
 //
 
-use error::errors::{*};
+use error::errors::*;
 use packet::*;
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::cmp;
 use std::cmp::min;
-use std::time::{Duration, Instant};
-use std::thread::{JoinHandle};
-use std::thread;
-use std::sync::{Arc, MutexGuard, Mutex};
+use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::thread;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
 /// Socket2 used to create the underlying UDP socket that sACN is sent on.
-use socket2::{Socket, Domain, Type};
+use socket2::{Domain, Socket, Type};
 
 /// UUID library used to handle the UUID's used in the CID fields.
 use uuid::Uuid;
@@ -83,7 +83,7 @@ pub struct SacnSource {
 
     /// Update thread which performs actions every DEFAULT_POLL_PERIOD such as checking if a universe 
     /// discovery packet should be sent.
-    update_thread: Option<JoinHandle<()>>
+    update_thread: Option<JoinHandle<()>>,
 }
 
 /// Internal sACN sender, this does most of the work however is encapsulated within SacnSource
@@ -147,7 +147,10 @@ impl SacnSource {
     /// # Errors
     /// See (with_cid_ip)[with_cid_ip]
     pub fn with_cid_v4(name: &str, cid: Uuid) -> Result<SacnSource> {
-        let ip = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), ACN_SDT_MULTICAST_PORT);
+        let ip = SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            ACN_SDT_MULTICAST_PORT,
+        );
         SacnSource::with_cid_ip(name, cid, ip)
     }
 
@@ -166,7 +169,10 @@ impl SacnSource {
     /// # Errors
     /// See (with_cid_ip)[with_cid_ip]
     pub fn with_cid_v6(name: &str, cid: Uuid) -> Result<SacnSource> {
-        let ip = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)), ACN_SDT_MULTICAST_PORT);
+        let ip = SocketAddr::new(
+            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
+            ACN_SDT_MULTICAST_PORT,
+        );
         SacnSource::with_cid_ip(name, cid, ip)
     }
 
@@ -190,7 +196,9 @@ impl SacnSource {
     /// 
     pub fn with_cid_ip(name: &str, cid: Uuid, ip: SocketAddr) -> Result<SacnSource> {
         if name.len() > E131_SOURCE_NAME_FIELD_LENGTH {
-            bail!(ErrorKind::MalformedSourceName("Source name provided is longer than maximum allowed".to_string()));
+            bail!(ErrorKind::MalformedSourceName(
+                "Source name provided is longer than maximum allowed".to_string()
+            ));
         }
 
         let trd_builder = thread::Builder::new().name(SND_UPDATE_THREAD_NAME.into());
@@ -212,7 +220,6 @@ impl SacnSource {
                         _ => {
                             // In-case of an error on the discovery thread the source continues to operate and tries again.
                             // As no unsafe code blocks are used the rust compiler guarantees this is memory safe.
-                            
                         }
                     }
                 }
@@ -306,8 +313,21 @@ impl SacnSource {
     /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
     /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
     /// 
-    pub fn send(&mut self, universes: &[u16], data: &[u8], priority: Option<u8>, dst_ip: Option<SocketAddr>, synchronisation_addr: Option<u16>) -> Result<()> {
-        unlock_internal_mut(&mut self.internal)?.send(universes, data, priority, dst_ip, synchronisation_addr)
+    pub fn send(
+        &mut self,
+        universes: &[u16],
+        data: &[u8],
+        priority: Option<u8>,
+        dst_ip: Option<SocketAddr>,
+        synchronisation_addr: Option<u16>,
+    ) -> Result<()> {
+        unlock_internal_mut(&mut self.internal)?.send(
+            universes,
+            data,
+            priority,
+            dst_ip,
+            synchronisation_addr,
+        )
     }
 
     /// Sends a synchronisation packet to trigger the sending of packets waiting to be sent together.
@@ -528,13 +548,18 @@ impl SacnSource {
 impl Drop for SacnSource {
     fn drop(&mut self){
         match unlock_internal_mut(&mut self.internal) {
-            Ok(mut i) => { i.running = false; }
-            Err(_) => { return; } // As drop isn't always explicitly called and cannot return an error the error is ignored. Memory safety is maintain and this prevents causing a panic!.
+            Ok(mut i) => {
+                i.running = false;
+            }
+            Err(_) => {
+                return;
+            } // As drop isn't always explicitly called and cannot return an error the error is ignored. Memory safety is maintain and this prevents causing a panic!.
         };
 
         if let Some(thread) = self.update_thread.take() {
             {
-                match unlock_internal_mut(&mut self.internal) { // Internal is accessed twice separately, this allows the discovery thread to interleave between running being set to false speeding up termination.
+                match unlock_internal_mut(&mut self.internal) {
+                    // Internal is accessed twice separately, this allows the discovery thread to interleave between running being set to false speeding up termination.
                     Ok(mut i) => { 
                         match i.terminate(DEFAULT_TERMINATE_START_CODE) {
                             _ => {} // For same reasons as above a potential error is ignored and a 'best attempt' is used to clean up.
@@ -566,11 +591,13 @@ impl SacnSourceInternal {
     /// 
     fn with_cid_ip(name: &str, cid: Uuid, ip: SocketAddr) -> Result<SacnSourceInternal> {
         let socket = if ip.is_ipv4() {
-            Socket::new(Domain::ipv4(), Type::dgram(), None).unwrap()
+            Socket::new(Domain::IPV4, Type::DGRAM, None).unwrap()
         } else if ip.is_ipv6() {
-            Socket::new(Domain::ipv6(), Type::dgram(), None).unwrap()
+            Socket::new(Domain::IPV6, Type::DGRAM, None).unwrap()
         } else {
-            bail!(ErrorKind::UnsupportedIpVersion("Address to create SacnSource is not IPv4 or IPv6".to_string()));
+            bail!(ErrorKind::UnsupportedIpVersion(
+                "Address to create SacnSource is not IPv4 or IPv6".to_string()
+            ));
         };
         
         // Multiple different processes might want to send to the sACN stream so therefore need to allow re-using the ACN port.
@@ -593,7 +620,7 @@ impl SacnSourceInternal {
             universes: Vec::new(),
             running: true,
             last_discovery_advert_timestamp: Instant::now(),
-            is_sending_discovery: true
+            is_sending_discovery: true,
         };
 
         Ok(ds)
@@ -642,7 +669,8 @@ impl SacnSourceInternal {
             self.universes.push(universe);
         } else {
             match self.universes.binary_search(&universe) {
-                Err(i) => { // Value not found, i is the position it should be inserted
+                Err(i) => {
+                    // Value not found, i is the position it should be inserted
                     self.universes.insert(i, universe);
                 }
                 Ok(_) => {
@@ -664,10 +692,14 @@ impl SacnSourceInternal {
         is_universe_in_range(universe)?;
 
         match self.universes.binary_search(&universe) {
-            Err(_i) => { // Value not found
-                bail!(ErrorKind::UniverseNotFound("Attempted to de-register a universe that was never registered".to_string()))
+            Err(_i) => {
+                // Value not found
+                bail!(ErrorKind::UniverseNotFound(
+                    "Attempted to de-register a universe that was never registered".to_string()
+                ))
             }
-            Ok(i) => { // Value found, i is index.
+            Ok(i) => {
+                // Value found, i is index.
                 self.universes.remove(i);
                 Ok(())
             }
@@ -685,7 +717,9 @@ impl SacnSourceInternal {
         is_universe_in_range(*u)?;
 
         if !self.universes.contains(u) {
-            bail!(ErrorKind::UniverseNotRegistered(format!("Attempted to send on unregistered universe : {}", u).to_string()));
+            bail!(ErrorKind::UniverseNotRegistered(
+                format!("Attempted to send on unregistered universe : {}", u).to_string()
+            ));
         }
 
         Ok(())
@@ -728,13 +762,26 @@ impl SacnSourceInternal {
     /// 
     /// Io: Returned if the data fails to be sent on the socket, see send_to(fn.send_to.Socket).
     /// 
-    fn send(&self, universes: &[u16], data: &[u8], priority: Option<u8>, dst_ip: Option<SocketAddr>, synchronisation_addr: Option<u16>) -> Result<()> {
-        if self.running == false { // Indicates that this sender has been terminated.
-            bail!(ErrorKind::SenderAlreadyTerminated("Attempted to send".to_string())); 
+    fn send(
+        &self,
+        universes: &[u16],
+        data: &[u8],
+        priority: Option<u8>,
+        dst_ip: Option<SocketAddr>,
+        synchronisation_addr: Option<u16>,
+    ) -> Result<()> {
+        if self.running == false {
+            // Indicates that this sender has been terminated.
+            bail!(ErrorKind::SenderAlreadyTerminated(
+                "Attempted to send".to_string()
+            ));
         }
 
         if data.len() == 0 {
-           bail!(std::io::Error::new(std::io::ErrorKind::InvalidInput, "Must provide data to send, data.len() == 0"));
+            bail!(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Must provide data to send, data.len() == 0"
+            ));
         }
 
         // Check all the given universes are valid before doing any action.
@@ -745,14 +792,22 @@ impl SacnSourceInternal {
 
         // Check that the synchronisation universe is also valid.
         if synchronisation_addr.is_some() {
-            self.universe_allowed(&synchronisation_addr.unwrap()).chain_err(|| "Synchronisation universe not allowed")?;
+            self.universe_allowed(&synchronisation_addr.unwrap())
+                .chain_err(|| "Synchronisation universe not allowed")?;
         }
 
         // + 1 as there must be at least 1 universe required as the data isn't empty then additional universes for any more.
-        let required_universes = (data.len() as f64 / UNIVERSE_CHANNEL_CAPACITY as f64).ceil() as usize;
+        let required_universes =
+            (data.len() as f64 / UNIVERSE_CHANNEL_CAPACITY as f64).ceil() as usize;
 
         if universes.len() < required_universes {
-            bail!(std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("Must provide enough universes to send on, universes provided: {}", universes.len())));
+            bail!(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "Must provide enough universes to send on, universes provided: {}",
+                    universes.len()
+                )
+            ));
         }
         
         for i in 0 .. required_universes {
@@ -760,8 +815,13 @@ impl SacnSourceInternal {
             // Safety check to make sure that the end index doesn't exceed the data length
             let end_index = cmp::min((i + 1) * UNIVERSE_CHANNEL_CAPACITY, data.len());
 
-            self.send_universe(universes[i], &data[start_index .. end_index], 
-                priority.unwrap_or(E131_DEFAULT_PRIORITY), &dst_ip, synchronisation_addr.unwrap_or(NO_SYNC_UNIVERSE))?;
+            self.send_universe(
+                universes[i],
+                &data[start_index..end_index],
+                priority.unwrap_or(E131_DEFAULT_PRIORITY),
+                &dst_ip,
+                synchronisation_addr.unwrap_or(NO_SYNC_UNIVERSE),
+            )?;
         }
 
         Ok(())
@@ -790,13 +850,23 @@ impl SacnSourceInternal {
     /// 
     /// Io: Returned if the data fails to be sent on the socket, see send_to(fn.send_to.Socket).
     /// 
-    fn send_universe(&self, universe: u16, data: &[u8], priority: u8, dst_ip: &Option<SocketAddr>, sync_address: u16) -> Result<()> {
+    fn send_universe(
+        &self,
+        universe: u16,
+        data: &[u8],
+        priority: u8,
+        dst_ip: &Option<SocketAddr>,
+        sync_address: u16,
+    ) -> Result<()> {
         if priority > E131_MAX_PRIORITY {
             bail!(ErrorKind::InvalidPriority(format!("Priority must be within allowed range of [0-E131_MAX_PRIORITY], priority provided: {}", priority)));
         }
 
         if data.len() > UNIVERSE_CHANNEL_CAPACITY {
-            bail!(ErrorKind::ExceedUniverseCapacity(format!("Data provided must fit in a single universe, data len: {}", data.len())));
+            bail!(ErrorKind::ExceedUniverseCapacity(format!(
+                "Data provided must fit in a single universe, data len: {}",
+                data.len()
+            )));
         }
 
         let mut sequence = match self.data_sequences.borrow().get(&universe) {
@@ -828,17 +898,23 @@ impl SacnSourceInternal {
         };
 
         if dst_ip.is_some() {
-            self.socket.send_to(&packet.pack_alloc().unwrap(), &dst_ip.unwrap().into()).chain_err(|| "Failed to send data unicast on socket")?;
+            self.socket
+                .send_to(&packet.pack_alloc().unwrap(), &dst_ip.unwrap().into())
+                .chain_err(|| "Failed to send data unicast on socket")?;
         } else {
             let dst;
 
             if self.addr.is_ipv6(){
-                dst = universe_to_ipv6_multicast_addr(universe).chain_err(|| "Failed to convert universe to Ipv6 multicast address")?;
+                dst = universe_to_ipv6_multicast_addr(universe)
+                    .chain_err(|| "Failed to convert universe to Ipv6 multicast address")?;
             } else {
-                dst = universe_to_ipv4_multicast_addr(universe).chain_err(|| "Failed to convert universe to Ipv4 multicast address")?;
+                dst = universe_to_ipv4_multicast_addr(universe)
+                    .chain_err(|| "Failed to convert universe to Ipv4 multicast address")?;
             }
 
-            self.socket.send_to(&packet.pack_alloc().unwrap(), &dst).chain_err(|| "Failed to send data multicast on socket")?;
+            self.socket
+                .send_to(&packet.pack_alloc().unwrap(), &dst)
+                .chain_err(|| "Failed to send data multicast on socket")?;
         }
 
         if sequence == 255 {
@@ -894,11 +970,13 @@ impl SacnSourceInternal {
                 cid: self.cid,
                 data: E131RootLayerData::SynchronizationPacket(SynchronizationPacketFramingLayer {
                     sequence_number: sequence,
-                    synchronization_address: universe
-                })
-            }
+                    synchronization_address: universe,
+                }),
+            },
         };
-        self.socket.send_to(&packet.pack_alloc()?, &ip).chain_err(|| "Failed to send sync packet on socket")?;
+        self.socket
+            .send_to(&packet.pack_alloc()?, &ip)
+            .chain_err(|| "Failed to send sync packet on socket")?;
 
         if sequence == 255 {
             sequence = 0;
@@ -925,7 +1003,12 @@ impl SacnSourceInternal {
     /// 
     /// Io: Returned if the termination packets fail to be sent on the underlying socket.
     /// 
-    fn send_terminate_stream_pkt(&self, universe: u16, dst_ip: Option<SocketAddr>, start_code: u8) -> Result<()> {
+    fn send_terminate_stream_pkt(
+        &self,
+        universe: u16,
+        dst_ip: Option<SocketAddr>,
+        start_code: u8,
+    ) -> Result<()> {
         self.universe_allowed(&universe)?;
 
         let ip = match dst_ip{
@@ -1034,8 +1117,15 @@ impl SacnSourceInternal {
 
         for p in 0 .. pages_req {
             let start_index = (p as usize) * DISCOVERY_UNI_PER_PAGE;
-            let end_index = min( ((p as usize) + 1) * DISCOVERY_UNI_PER_PAGE , self.universes.len());
-            self.send_universe_discovery_detailed(p, pages_req - 1, &self.universes[start_index .. end_index])?;
+            let end_index = min(
+                ((p as usize) + 1) * DISCOVERY_UNI_PER_PAGE,
+                self.universes.len(),
+            );
+            self.send_universe_discovery_detailed(
+                p,
+                pages_req - 1,
+                &self.universes[start_index..end_index],
+            )?;
         }
         Ok(())
     }
@@ -1057,7 +1147,12 @@ impl SacnSourceInternal {
     /// 
     /// SacnParsePackError: Returned if the discovery packet cannot be packed to send.
     /// 
-    fn send_universe_discovery_detailed(&self, page: u8, last_page: u8, universes: &[u16]) -> Result<()>{
+    fn send_universe_discovery_detailed(
+        &self,
+        page: u8,
+        last_page: u8,
+        universes: &[u16],
+    ) -> Result<()> {
         let packet = AcnRootLayerProtocol {
             pdu: E131RootLayer {
                 cid: self.cid,
@@ -1115,7 +1210,9 @@ impl SacnSourceInternal {
     /// 
     fn set_name(&mut self, name: &str) -> Result<()> {
         if name.len() > E131_SOURCE_NAME_FIELD_LENGTH {
-            bail!(ErrorKind::MalformedSourceName("Source name provided is longer than maximum allowed".to_string()));
+            bail!(ErrorKind::MalformedSourceName(
+                "Source name provided is longer than maximum allowed".to_string()
+            ));
         }
         self.name = name.to_string();
 
@@ -1212,7 +1309,9 @@ impl SacnSourceInternal {
 /// SourceCorrupt: Returned if the Mutex used to control access to the internal sender is poisoned by a thread encountering
 /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
 /// 
-fn unlock_internal(internal: &Arc<Mutex<SacnSourceInternal>>) -> Result<MutexGuard<SacnSourceInternal>> {
+fn unlock_internal(
+    internal: &Arc<Mutex<SacnSourceInternal>>,
+) -> Result<MutexGuard<SacnSourceInternal>> {
     match internal.lock() {
         Err(_) => {
             // The PoisonError returned doesn't contain further information and just allows access to the internal potentially inconsistent sender which 
@@ -1221,9 +1320,7 @@ fn unlock_internal(internal: &Arc<Mutex<SacnSourceInternal>>) -> Result<MutexGua
             // error_chain.
             bail!(ErrorKind::SourceCorrupt("Mutex poisoned".to_string()));
         }
-        Ok(lock) => {
-            Ok(lock)
-        }
+        Ok(lock) => Ok(lock),
     }
 }
 
@@ -1240,7 +1337,9 @@ fn unlock_internal(internal: &Arc<Mutex<SacnSourceInternal>>) -> Result<MutexGua
 /// Returns an SourceCorrupt error if the Mutex used to control access to the internal sender is poisoned by a thread encountering
 /// a panic while accessing causing the source to be left in a potentially inconsistent state. 
 /// 
-fn unlock_internal_mut(internal: &mut Arc<Mutex<SacnSourceInternal>>) -> Result<MutexGuard<SacnSourceInternal>> {
+fn unlock_internal_mut(
+    internal: &mut Arc<Mutex<SacnSourceInternal>>,
+) -> Result<MutexGuard<SacnSourceInternal>> {
     match internal.lock() {
         Err(_) => {
             // The PoisonError returned doesn't contain further information and just allows access to the internal potentially inconsistent sender which 
@@ -1249,9 +1348,7 @@ fn unlock_internal_mut(internal: &mut Arc<Mutex<SacnSourceInternal>>) -> Result<
             // error_chain.
             bail!(ErrorKind::SourceCorrupt("Mutex poisoned".to_string()));
         }
-        Ok(lock) => {
-            Ok(lock)
-        }
+        Ok(lock) => Ok(lock),
     }
 }
 
@@ -1269,7 +1366,10 @@ fn unlock_internal_mut(internal: &mut Arc<Mutex<SacnSourceInternal>>) -> Result<
 /// 
 fn perform_periodic_update(src: &mut Arc<Mutex<SacnSourceInternal>>) -> Result<()>{
     let mut unwrap_src = unlock_internal_mut(src)?;
-    if unwrap_src.is_sending_discovery && Instant::now().duration_since(unwrap_src.last_discovery_advert_timestamp) > E131_UNIVERSE_DISCOVERY_INTERVAL {
+    if unwrap_src.is_sending_discovery
+        && Instant::now().duration_since(unwrap_src.last_discovery_advert_timestamp)
+            > E131_UNIVERSE_DISCOVERY_INTERVAL
+    {
         unwrap_src.send_universe_discovery()?;
         unwrap_src.last_discovery_advert_timestamp = Instant::now();
     }

--- a/tests/data_parse_tests.rs
+++ b/tests/data_parse_tests.rs
@@ -3170,7 +3170,7 @@ fn test_data_packet_full_length_expected() {
 fn test_data_packet_empty_capacity_parse_pack() {
     let packet = AcnRootLayerProtocol {
         pdu: E131RootLayer {
-            cid: Uuid::from_bytes(&TEST_DATA_PACKET_EMPTY[22..38]).unwrap(),
+            cid: Uuid::from_bytes(TEST_DATA_PACKET_EMPTY[22..38].try_into().unwrap()),
             data: E131RootLayerData::DataPacket(DataPacketFramingLayer {
                 source_name: "Source_A".into(),
                 priority: 100,
@@ -3202,7 +3202,7 @@ fn test_data_packet_empty_capacity_parse_pack() {
 fn test_data_packet_partial_capacity_parse_pack() {
     let packet = AcnRootLayerProtocol {
         pdu: E131RootLayer {
-            cid: Uuid::from_bytes(&TEST_DATA_PACKET_PARTIAL[22..38]).unwrap(),
+            cid: Uuid::from_bytes(TEST_DATA_PACKET_PARTIAL[22..38].try_into().unwrap()),
             data: E131RootLayerData::DataPacket(DataPacketFramingLayer {
                 source_name: "Source_A".into(),
                 priority: 100,
@@ -3234,7 +3234,7 @@ fn test_data_packet_partial_capacity_parse_pack() {
 fn test_data_packet_parse_pack() {
     let packet = AcnRootLayerProtocol {
         pdu: E131RootLayer {
-            cid: Uuid::from_bytes(&TEST_DATA_PACKET[22..38]).unwrap(),
+            cid: Uuid::from_bytes(TEST_DATA_PACKET[22..38].try_into().unwrap()),
             data: E131RootLayerData::DataPacket(DataPacketFramingLayer {
                 source_name: "Source_A".into(),
                 priority: 100,
@@ -3638,7 +3638,7 @@ fn test_malformed_data_packet_framing_layer_wrong_vector_parse() {
 fn test_data_packet_max_source_name_length_parse(){
     let packet = AcnRootLayerProtocol {
         pdu: E131RootLayer {
-            cid: Uuid::from_bytes(&TEST_DATA_PACKET_MAX_SOURCE_NAME[22..38]).unwrap(),
+            cid: Uuid::from_bytes(TEST_DATA_PACKET_MAX_SOURCE_NAME[22..38].try_into().unwrap()),
             data: E131RootLayerData::DataPacket(DataPacketFramingLayer {
                 source_name: "SourcSourcSourcSourcSourcSourcSourcSourcSourcSourcSourcSourcSou".into(),
                 priority: 100,

--- a/tests/discovery_parse_tests.rs
+++ b/tests/discovery_parse_tests.rs
@@ -775,7 +775,7 @@ const TEST_UNIVERSE_DISCOVERY_PACKET_RANDOM_ORDER: &[u8] = &[
 fn test_discovery_packet_parse_pack() {
     let packet = AcnRootLayerProtocol {
         pdu: E131RootLayer {
-            cid: Uuid::from_bytes(&TEST_UNIVERSE_DISCOVERY_PACKET[22..38]).unwrap(),
+            cid: Uuid::from_bytes(TEST_UNIVERSE_DISCOVERY_PACKET[22..38].try_into().unwrap()),
             data: E131RootLayerData::UniverseDiscoveryPacket(UniverseDiscoveryPacketFramingLayer {
                 source_name: "Source_A".into(),
                 data: UniverseDiscoveryPacketUniverseDiscoveryLayer {

--- a/tests/ipv6_tests.rs
+++ b/tests/ipv6_tests.rs
@@ -959,7 +959,7 @@ fn test_ansi_e131_appendix_b_runthrough_ipv6() {
     let source_name = "Source_A";
     let data = [0x00, 0xe, 0x0, 0xc, 0x1, 0x7, 0x1, 0x4, 0x8, 0x0, 0xd, 0xa, 0x7, 0xa];
     let data2 = [0x00, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0xa];
-    let src_cid: Uuid = Uuid::from_bytes(&[0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e]).unwrap();
+    let src_cid: Uuid = Uuid::from_bytes([0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e].try_into().unwrap());
 
     let snd_thread = thread::spawn(move || {
         let ip: SocketAddr = SocketAddr::new(TEST_NETWORK_INTERFACE_IPV6[0].parse().unwrap(), ACN_SDT_MULTICAST_PORT + 1);
@@ -1092,7 +1092,7 @@ fn test_discover_recv_sync_runthrough_ipv6() {
     const DATA2: [u8; 16] =[0x00, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0xa, 0x9, 0x8];
 
     // The source CID.
-    let src_cid: Uuid = Uuid::from_bytes(&[0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e]).unwrap();
+    let src_cid: Uuid = Uuid::from_bytes([0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e].try_into().unwrap());
 
     let snd_thread = thread::spawn(move || {
         let ip: SocketAddr = SocketAddr::new(TEST_NETWORK_INTERFACE_IPV6[0].parse().unwrap(), ACN_SDT_MULTICAST_PORT + 1);
@@ -1219,13 +1219,13 @@ fn test_ip_equivalence() {
 
     // Create and setup the ipv4 source.
     let ipv4: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), ACN_SDT_MULTICAST_PORT + 1);
-    let mut ipv4_source = SacnSource::with_cid_ip(&source_name.clone(), Uuid::from_bytes(&CID).unwrap(), ipv4).unwrap();
+    let mut ipv4_source = SacnSource::with_cid_ip(&source_name.clone(), Uuid::from_bytes(CID), ipv4).unwrap();
     ipv4_source.set_preview_mode(false).unwrap();
     ipv4_source.set_multicast_loop_v4(true).unwrap();
     ipv4_source.register_universes(&[universe as u16]).unwrap();
 
     // Create and setup the ipv4 receiver socket.
-    let ipv4_recv = Socket::new(Domain::ipv4(), Type::dgram(), None).unwrap();
+    let mut ipv4_recv = Socket::new(Domain::IPV4, Type::DGRAM, None).unwrap();
     let ipv4_multicast_addr = universe_to_ipv4_multicast_addr(universe).unwrap();
     let ipv4_discovery_multicast_addr = universe_to_ipv4_multicast_addr(E131_DISCOVERY_UNIVERSE).unwrap();
 
@@ -1236,17 +1236,17 @@ fn test_ip_equivalence() {
     // Bind to the unspecified 0.0.0.0 address allowing receiving any data on that port then join the universe and the discovery multicast groups.
     // Binding to unspecified required to allow receiving from multiple multicast addresses.
     ipv4_recv.bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), ACN_SDT_MULTICAST_PORT).into()).unwrap();
-    ipv4_recv.join_multicast_v4(&ipv4_multicast_addr.as_inet().unwrap().ip(), &Ipv4Addr::UNSPECIFIED).unwrap();
-    ipv4_recv.join_multicast_v4(&ipv4_discovery_multicast_addr.as_inet().unwrap().ip(), &Ipv4Addr::UNSPECIFIED).unwrap();
+    ipv4_recv.join_multicast_v4(&ipv4_multicast_addr.as_socket_ipv4().unwrap().ip(), &Ipv4Addr::UNSPECIFIED).unwrap();
+    ipv4_recv.join_multicast_v4(&ipv4_discovery_multicast_addr.as_socket_ipv4().unwrap().ip(), &Ipv4Addr::UNSPECIFIED).unwrap();
     
     // Create and setup the ipv6 source.
     let ipv6: SocketAddr = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), ACN_SDT_MULTICAST_PORT + 1);
-    let mut ipv6_source = SacnSource::with_cid_ip(&source_name.clone(), Uuid::from_bytes(&CID).unwrap(), ipv6).unwrap();
+    let mut ipv6_source = SacnSource::with_cid_ip(&source_name.clone(), Uuid::from_bytes(CID), ipv6).unwrap();
     ipv6_source.set_preview_mode(false).unwrap();
     ipv6_source.register_universes(&[universe]).unwrap();
 
     // Create and setup the ipv6 receiver socket.
-    let ipv6_recv = Socket::new(Domain::ipv6(), Type::dgram(), None).unwrap();
+    let mut ipv6_recv = Socket::new(Domain::IPV6, Type::DGRAM, None).unwrap();
     let ipv6_multicast_addr = universe_to_ipv6_multicast_addr(universe).unwrap();
     let ipv6_discovery_multicast_addr = universe_to_ipv6_multicast_addr(E131_DISCOVERY_UNIVERSE).unwrap();
 
@@ -1256,18 +1256,18 @@ fn test_ip_equivalence() {
 
     // Bind to the unspecified :: address for same reason as for IPv4.
     ipv6_recv.bind(&SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), ACN_SDT_MULTICAST_PORT).into()).unwrap();
-    ipv6_recv.join_multicast_v6(&ipv6_multicast_addr.as_inet6().unwrap().ip(), 0).unwrap();
-    ipv6_recv.join_multicast_v6(&ipv6_discovery_multicast_addr.as_inet6().unwrap().ip(), 0).unwrap();
+    ipv6_recv.join_multicast_v6(&ipv6_multicast_addr.as_socket_ipv6().unwrap().ip(), 0).unwrap();
+    ipv6_recv.join_multicast_v6(&ipv6_discovery_multicast_addr.as_socket_ipv6().unwrap().ip(), 0).unwrap();
     
     // Send and receive the data packet over IPv4.
     let mut ipv4_recv_buf = [0; 1024];
     ipv4_source.send(&[universe], &dmx_data, Some(PRIORITY), None, None).unwrap();
-    let (ipv4_len, _) = ipv4_recv.recv_from(&mut ipv4_recv_buf).unwrap();
+    let ipv4_len = ipv4_recv.read(&mut ipv4_recv_buf).unwrap();
 
     // Send and receive the data packet over IPv6.
     let mut ipv6_recv_buf = [0; 1024];
     ipv6_source.send(&[universe], &dmx_data, Some(PRIORITY), None, None).unwrap();
-    let (ipv6_len, _) = ipv6_recv.recv_from(&mut ipv6_recv_buf).unwrap();
+    let ipv6_len = ipv6_recv.read(&mut ipv6_recv_buf).unwrap();
 
     // Check that the data packets match.
     assert_eq!(ipv4_recv_buf[.. ipv4_len], ipv6_recv_buf[.. ipv6_len], "IPv4 and IPv6 data packets aren't identical");
@@ -1275,23 +1275,23 @@ fn test_ip_equivalence() {
     // Send and receive the sync packet over IPv4.
     ipv4_recv_buf = [0; 1024];
     ipv4_source.send_sync_packet(universe, None).unwrap();
-    let (ipv4_len, _) = ipv4_recv.recv_from(&mut ipv4_recv_buf).unwrap();
+    let ipv4_len = ipv4_recv.read(&mut ipv4_recv_buf).unwrap();
 
     // Send and receive the sync packet over IPv6.
     ipv6_recv_buf = [0; 1024];
     ipv6_source.send_sync_packet(universe, None).unwrap();
-    let (ipv6_len, _) = ipv6_recv.recv_from(&mut ipv6_recv_buf).unwrap();
+    let ipv6_len = ipv6_recv.read(&mut ipv6_recv_buf).unwrap();
 
     // Check the sync packets match.
     assert_eq!(ipv4_recv_buf[.. ipv4_len], ipv6_recv_buf[.. ipv6_len], "IPv4 and IPv6 sync packets aren't identical");
 
     // Wait for discovery packet over IPv4.
     ipv4_recv_buf = [0; 1024];
-    let (ipv4_len, _) = ipv4_recv.recv_from(&mut ipv4_recv_buf).unwrap();
+    let ipv4_len = ipv4_recv.read(&mut ipv4_recv_buf).unwrap();
 
     // Wait for discovery packet over IPv6.
     ipv6_recv_buf = [0; 1024];
-    let (ipv6_len, _) = ipv6_recv.recv_from(&mut ipv6_recv_buf).unwrap();
+    let ipv6_len = ipv6_recv.read(&mut ipv6_recv_buf).unwrap();
 
     // Check the discovery packets match.
     assert_eq!(ipv4_recv_buf[.. ipv4_len], ipv6_recv_buf[.. ipv6_len], "IPv4 and IPv6 discovery packets aren't identical");
@@ -1304,11 +1304,11 @@ fn test_ip_equivalence() {
     for _ in 0 .. E131_TERMINATE_STREAM_PACKET_COUNT {
         // Send and receive a termination packet over IPv4.
         ipv4_recv_buf = [0; 1024];
-        let (ipv4_len, _) = ipv4_recv.recv_from(&mut ipv4_recv_buf).unwrap();
+        let ipv4_len = ipv4_recv.read(&mut ipv4_recv_buf).unwrap();
 
         // Send and receive a termination packet over IPv6.
         ipv6_recv_buf = [0; 1024];
-        let (ipv6_len, _) = ipv6_recv.recv_from(&mut ipv6_recv_buf).unwrap();
+        let ipv6_len = ipv6_recv.read(&mut ipv6_recv_buf).unwrap();
 
         // Check that the termination packets match
         assert_eq!(ipv4_recv_buf[.. ipv4_len], ipv6_recv_buf[.. ipv6_len], "IPv4 and IPv6 termination packets aren't identical");

--- a/tests/sync_parse_tests.rs
+++ b/tests/sync_parse_tests.rs
@@ -391,7 +391,7 @@ fn test_sync_packet_length() {
 fn test_synchronization_packet_parse_pack() {
     let packet = AcnRootLayerProtocol {
         pdu: E131RootLayer {
-            cid: Uuid::from_bytes(&TEST_SYNCHRONIZATION_PACKET[22..38]).unwrap(),
+            cid: Uuid::from_bytes(TEST_SYNCHRONIZATION_PACKET[22..38].try_into().unwrap()),
             data: E131RootLayerData::SynchronizationPacket(SynchronizationPacketFramingLayer {
                 sequence_number: 0x70,
                 synchronization_address: 7962,


### PR DESCRIPTION
This PR updates uuid to v1.12 (not updated all the way to 1.16 in order to remain compatible with latest bevy v0.15.3) and socket2 v0.5.9, both of which include breaking changes that required some minor refactoring.