### PR TITLE
Update cargo example target names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,6 @@ std = []
 [badges]
 travis-ci = { repository = "Lan2u/RustSacn" }
 
-[[examples]]
+[[example]]
 path = 'examples/sine-wave-sender.rs'
 edition = '2024'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,17 @@ std = []
 travis-ci = { repository = "Lan2u/RustSacn" }
 
 [[example]]
+name = 'sine-wave-receiver'
+path = 'examples/sine-wave-receiver.rs'
+
+[[example]]
+name = 'sine-wave-sender'
 path = 'examples/sine-wave-sender.rs'
-edition = '2024'
+
+[[example]]
+name = 'demo_rcv'
+path = 'examples/demo_rcv/src/main.rs'  
+
+[[example]]
+name = 'demo_snd'
+path = 'examples/demo_snd/src/main.rs'


### PR DESCRIPTION
fixes the formatting and naming of the [[example]] targets