### PR TITLE
Receiver - Change recv to use read() instead of read_exact()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 **/*.rs.bk
 
 .vscode
+
+/local/

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,6 +43,17 @@ pub mod errors {
         }
 
         errors {
+            /// Returned to indicate that too many bytes were read to fit into supplied buffer.
+            ///
+            /// # Arguments
+            /// n: number of bytes read.
+            /// buf_size: size of buffer.
+            ///
+            TooManyBytesRead(n: usize, buf_size: usize) {
+                description("Too many bytes were read from the socket to fit in the supplied buffer."),
+                display("The given buffer fits {} bytes, but {} bytes were read.", buf_size, n)
+            }
+
             /// Returned to indicate that an invalid or malformed source name was used.
             ///
             /// # Arguments

--- a/src/receive.rs
+++ b/src/receive.rs
@@ -1213,8 +1213,8 @@ impl SacnNetworkReceiver {
         &mut self,
         buf: &'a mut [u8; RCV_BUF_DEFAULT_SIZE],
     ) -> Result<AcnRootLayerProtocol<'a>> {
-        // use read() for the windows impl, since windows does not like using read_exact()
-        if let Ok(n) = self.socket.read(buf) && n > RCV_BUF_DEFAULT_SIZE {
+        let n = self.socket.read(buf)?;
+        if n > RCV_BUF_DEFAULT_SIZE {
             bail!(TooManyBytesRead(n, RCV_BUF_DEFAULT_SIZE));
         }
         Ok(AcnRootLayerProtocol::parse(buf)?)

--- a/src/receive.rs
+++ b/src/receive.rs
@@ -1374,7 +1374,6 @@ impl SacnNetworkReceiver {
         if n > RCV_BUF_DEFAULT_SIZE {
             bail!(TooManyBytesRead(n, RCV_BUF_DEFAULT_SIZE));
         }
-
         Ok(AcnRootLayerProtocol::parse(buf)?)
     }
 

--- a/src/receive.rs
+++ b/src/receive.rs
@@ -1213,6 +1213,7 @@ impl SacnNetworkReceiver {
         &mut self,
         buf: &'a mut [u8; RCV_BUF_DEFAULT_SIZE],
     ) -> Result<AcnRootLayerProtocol<'a>> {
+        // use read() for the windows impl, since windows does not like using read_exact()
         let n = self.socket.read(buf)?;
         if n > RCV_BUF_DEFAULT_SIZE {
             bail!(TooManyBytesRead(n, RCV_BUF_DEFAULT_SIZE));

--- a/src/receive.rs
+++ b/src/receive.rs
@@ -1213,8 +1213,10 @@ impl SacnNetworkReceiver {
         &mut self,
         buf: &'a mut [u8; RCV_BUF_DEFAULT_SIZE],
     ) -> Result<AcnRootLayerProtocol<'a>> {
-        self.socket.read_exact(buf)?;
-
+        // use read() for the windows impl, since windows does not like using read_exact()
+        if let Ok(n) = self.socket.read(buf) && n > RCV_BUF_DEFAULT_SIZE {
+            bail!(TooManyBytesRead(n, RCV_BUF_DEFAULT_SIZE));
+        }
         Ok(AcnRootLayerProtocol::parse(buf)?)
     }
 

--- a/src/receive.rs
+++ b/src/receive.rs
@@ -1369,7 +1369,11 @@ impl SacnNetworkReceiver {
         &mut self,
         buf: &'a mut [u8; RCV_BUF_DEFAULT_SIZE],
     ) -> Result<AcnRootLayerProtocol<'a>> {
-        self.socket.read_exact(buf)?;
+        // use read() since read_exact() was not passing the tests.
+        let n = self.socket.read(buf)?;
+        if n > RCV_BUF_DEFAULT_SIZE {
+            bail!(TooManyBytesRead(n, RCV_BUF_DEFAULT_SIZE));
+        }
 
         Ok(AcnRootLayerProtocol::parse(buf)?)
     }


### PR DESCRIPTION
Windows would throw an error (pasted below) until the read_exact() was changed to read().

error:
"A message sent on a datagram socket was larger than the internal message buffer or some other network limit, or the buffer used to receive a datagram into was smaller than the datagram itself."