### PR TITLE
[receive] fix sequence number check bug

### DIFF
--- a/src/receive.rs
+++ b/src/receive.rs
@@ -3310,9 +3310,6 @@ mod test {
         // - First packet from a source/universe should establish the baseline
         //   (regardless of its value; the standard does not require starting at 0).
         // - After receiving 250..255, receiving 0 should be accepted as a wrap.
-        //
-        // Current implementation likely FAILS because it computes diff using normal
-        // integer subtraction rather than signed 8-bit arithmetic.
 
         const UNIVERSE: u16 = 1;
         let src_cid: Uuid = Uuid::from_bytes([


### PR DESCRIPTION
Fix logic bug that wrongly accepts packets when wrapping the u8 sequence number range.

old seq number: 1
new seq number 254

e1.31 spec says to discard since it is within the -20, 0 difference range.

current seq diff on main: 254 - 1 = 253 as isize
accepted incorrectly

this pr: 254 - 1 = 253 as i8 = -3
-3 is within the discard window, so it correctly discards the packet.